### PR TITLE
input expr support wildcard

### DIFF
--- a/polars_ols/least_squares.py
+++ b/polars_ols/least_squares.py
@@ -168,7 +168,7 @@ def _pre_process_data(
         Tuple containing the pre-processed target, features, and sample weights.
     """
     target = parse_into_expr(target).cast(pl.Float64)
-    features = [f.cast(pl.Float64) for f in features]
+    features = [parse_into_expr(f).cast(pl.Float64) for f in features]
     # handle intercept
     if add_intercept:
         if any(f.meta.output_name == "const" for f in features):
@@ -229,6 +229,7 @@ def compute_least_squares(
                 is_elementwise=False,
                 changes_length=True,
                 returns_scalar=True,
+                input_wildcard_expansion=True,
             )
             .alias("coefficients")
             .struct.rename_fields([f.meta.output_name() for f in features])
@@ -241,6 +242,7 @@ def compute_least_squares(
                 args=[target, *features],
                 kwargs=ols_kwargs.to_dict(),
                 is_elementwise=False,
+                input_wildcard_expansion=True,
             )
             / sqrt_w
         )  # undo the sqrt(w) scaling implicit in predictions
@@ -293,6 +295,7 @@ def compute_recursive_least_squares(
                 args=[target, *features],
                 kwargs=rls_kwargs.to_dict(),
                 is_elementwise=False,
+                input_wildcard_expansion=True,
             )
             .alias("coefficients")
             .struct.rename_fields([f.meta.output_name() for f in features])
@@ -305,6 +308,7 @@ def compute_recursive_least_squares(
                 args=[target, *features],
                 kwargs=rls_kwargs.to_dict(),
                 is_elementwise=False,
+                input_wildcard_expansion=True,
             )
             / sqrt_w
         )  # undo the sqrt(w) scaling implicit in predictions
@@ -354,6 +358,7 @@ def compute_rolling_least_squares(
                 args=[target, *features],
                 kwargs=rolling_kwargs.to_dict(),
                 is_elementwise=False,
+                input_wildcard_expansion=True,
             )
             .alias("coefficients")
             .struct.rename_fields([f.meta.output_name() for f in features])
@@ -366,6 +371,7 @@ def compute_rolling_least_squares(
                 args=[target, *features],
                 kwargs=rolling_kwargs.to_dict(),
                 is_elementwise=False,
+                input_wildcard_expansion=True,
             )
             / sqrt_w
         )  # undo the sqrt(w) scaling implicit in predictions
@@ -451,4 +457,5 @@ def predict(
         args=[coefficients, *(f.cast(pl.Float64) for f in features)],
         kwargs={"null_policy": null_policy},
         is_elementwise=False,
+        input_wildcard_expansion=True,
     ).alias(name or "predictions")


### PR DESCRIPTION
Use Case
```python
import polars as pl
import polars_ols as pls  # noqa
from polars_ols.least_squares import OLSKwargs, RollingKwargs

df = pl.DataFrame({
    "A": [9, 10, 11, 12],
    "B": [1, 2, 3, 4],
}).with_row_index()

df = df.with_columns(df.to_dummies('B'))
df = df.with_columns(pl.col('A').rolling_mean(3).alias('C'))
df = df.with_columns(pls.compute_least_squares(pl.col('A'),
                                               pl.col('B_1'), pl.col('B_2'), pl.col('B_3'), pl.col('B_4'), pl.col('C'),
                                               mode='residuals', ols_kwargs=OLSKwargs(null_policy='drop', solve_method='svd')).alias('resid1'))
df = df.with_columns(pls.compute_least_squares(pl.col('A'),
                                               pl.col(r"^B_\d+$"), pl.col('C'),
                                               mode='residuals', ols_kwargs=OLSKwargs(null_policy='drop', solve_method='svd')).alias('resid2'))
print(df)
"""
shape: (4, 10)
┌───────┬─────┬─────┬─────┬───┬─────┬──────┬─────────────┬─────────────┐
│ index ┆ A   ┆ B   ┆ B_1 ┆ … ┆ B_4 ┆ C    ┆ resid1      ┆ resid2      │
│ ---   ┆ --- ┆ --- ┆ --- ┆   ┆ --- ┆ ---  ┆ ---         ┆ ---         │
│ u32   ┆ i64 ┆ i64 ┆ u8  ┆   ┆ u8  ┆ f64  ┆ f64         ┆ f64         │
╞═══════╪═════╪═════╪═════╪═══╪═════╪══════╪═════════════╪═════════════╡
│ 0     ┆ 9   ┆ 1   ┆ 1   ┆ … ┆ 0   ┆ null ┆ null        ┆ null        │
│ 1     ┆ 10  ┆ 2   ┆ 0   ┆ … ┆ 0   ┆ null ┆ null        ┆ null        │
│ 2     ┆ 11  ┆ 3   ┆ 0   ┆ … ┆ 0   ┆ 10.0 ┆ -1.0658e-14 ┆ -1.0658e-14 │
│ 3     ┆ 12  ┆ 4   ┆ 0   ┆ … ┆ 1   ┆ 11.0 ┆ -8.8818e-15 ┆ -8.8818e-15 │
└───────┴─────┴─────┴─────┴───┴─────┴──────┴─────────────┴─────────────┘
"""
```