### PR TITLE
Reduce Python Layer Overhead

### DIFF
--- a/notebooks/polars_ols_demo.ipynb
+++ b/notebooks/polars_ols_demo.ipynb
@@ -2,19 +2,21 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "id": "8d7bae54-e858-410c-a574-da1aa325d90a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-10T20:33:36.562397Z",
-     "iopub.status.busy": "2024-04-10T20:33:36.561781Z",
-     "iopub.status.idle": "2024-04-10T20:33:36.714049Z",
-     "shell.execute_reply": "2024-04-10T20:33:36.713751Z",
-     "shell.execute_reply.started": "2024-04-10T20:33:36.562363Z"
+     "iopub.execute_input": "2024-04-12T16:17:09.795316Z",
+     "iopub.status.busy": "2024-04-12T16:17:09.794504Z",
+     "iopub.status.idle": "2024-04-12T16:17:09.803346Z",
+     "shell.execute_reply": "2024-04-12T16:17:09.802625Z",
+     "shell.execute_reply.started": "2024-04-12T16:17:09.795259Z"
     }
    },
    "outputs": [],
    "source": [
+    "import os; os.environ[\"POLARS_VERBOSE\"] = \"1\"\n",
+    "\n",
     "import polars as pl\n",
     "import polars_ols as pls\n",
     "import numpy as np"
@@ -22,15 +24,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "a070132d-27cd-4783-9799-f3b0a9f97ba9",
+   "execution_count": 6,
+   "id": "35076da5-137a-4d90-a671-ed1e9d650930",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-10T20:33:36.740536Z",
-     "iopub.status.busy": "2024-04-10T20:33:36.740340Z",
-     "iopub.status.idle": "2024-04-10T20:33:36.743664Z",
-     "shell.execute_reply": "2024-04-10T20:33:36.743240Z",
-     "shell.execute_reply.started": "2024-04-10T20:33:36.740522Z"
+     "iopub.execute_input": "2024-04-12T16:17:10.415486Z",
+     "iopub.status.busy": "2024-04-12T16:17:10.414948Z",
+     "iopub.status.idle": "2024-04-12T16:17:10.423544Z",
+     "shell.execute_reply": "2024-04-12T16:17:10.422534Z",
+     "shell.execute_reply.started": "2024-04-12T16:17:10.415447Z"
     }
    },
    "outputs": [],
@@ -40,12 +42,13 @@
     "               n_groups: int = 5,\n",
     "               noise: float = 0.1,\n",
     "              ) -> pl.DataFrame:\n",
-    "    x = np.random.normal(size=(n_samples, n_features))\n",
-    "    eps = np.random.normal(size=n_samples, scale=noise)\n",
+    "    rng = np.random.default_rng(0)\n",
+    "    x = rng.normal(size=(n_samples, n_features))\n",
+    "    eps = rng.normal(size=n_samples, scale=noise)\n",
     "    return pl.DataFrame(data=x, schema=[f\"x{i + 1}\" for i in range(n_features)]).with_columns(\n",
     "        y=pl.lit(-1 * x.sum(1) + eps),\n",
-    "        group=pl.lit(np.random.randint(0, n_groups, size=n_samples)),\n",
-    "        sample_weights=pl.lit(np.random.rand(n_samples)),\n",
+    "        group=pl.lit(rng.integers(0, n_groups, size=n_samples)),\n",
+    "        sample_weights=pl.lit(rng.uniform(0, 1, size=n_samples)),\n",
     "    )"
    ]
   },
@@ -55,11 +58,11 @@
    "id": "5ad1869e-d884-48e2-8f37-f790057ada1a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-10T20:33:37.232456Z",
-     "iopub.status.busy": "2024-04-10T20:33:37.232005Z",
-     "iopub.status.idle": "2024-04-10T20:33:37.247273Z",
-     "shell.execute_reply": "2024-04-10T20:33:37.246356Z",
-     "shell.execute_reply.started": "2024-04-10T20:33:37.232427Z"
+     "iopub.execute_input": "2024-04-12T15:34:32.207343Z",
+     "iopub.status.busy": "2024-04-12T15:34:32.205424Z",
+     "iopub.status.idle": "2024-04-12T15:34:32.225894Z",
+     "shell.execute_reply": "2024-04-12T15:34:32.223622Z",
+     "shell.execute_reply.started": "2024-04-12T15:34:32.207301Z"
     }
    },
    "outputs": [],
@@ -68,93 +71,44 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "52c33d88-7625-40af-a2e3-892e02ef61a1",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-04-10T20:33:37.624702Z",
-     "iopub.status.busy": "2024-04-10T20:33:37.624104Z",
-     "iopub.status.idle": "2024-04-10T20:33:37.635676Z",
-     "shell.execute_reply": "2024-04-10T20:33:37.634869Z",
-     "shell.execute_reply.started": "2024-04-10T20:33:37.624666Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (2_000, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>x1</th><th>x2</th><th>x3</th><th>y</th><th>group</th><th>sample_weights</th></tr><tr><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>i64</td><td>f64</td></tr></thead><tbody><tr><td>0.244378</td><td>0.29603</td><td>-1.591151</td><td>1.057149</td><td>3</td><td>0.350132</td></tr><tr><td>2.093035</td><td>-1.194226</td><td>1.174871</td><td>-2.008692</td><td>4</td><td>0.589495</td></tr><tr><td>0.26513</td><td>0.254817</td><td>1.908368</td><td>-2.423658</td><td>0</td><td>0.308177</td></tr><tr><td>-0.139459</td><td>0.201641</td><td>-0.750208</td><td>0.698626</td><td>1</td><td>0.378428</td></tr><tr><td>0.230555</td><td>1.111359</td><td>0.229246</td><td>-1.635799</td><td>1</td><td>0.138395</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>1.209234</td><td>-0.792829</td><td>0.277771</td><td>-0.895549</td><td>2</td><td>0.965688</td></tr><tr><td>-0.172662</td><td>-2.526893</td><td>-0.527852</td><td>3.20544</td><td>2</td><td>0.569951</td></tr><tr><td>1.835942</td><td>0.900255</td><td>1.29236</td><td>-4.14354</td><td>1</td><td>0.680204</td></tr><tr><td>-1.14397</td><td>0.672722</td><td>-0.133538</td><td>0.618378</td><td>3</td><td>0.438267</td></tr><tr><td>-0.585489</td><td>-2.278198</td><td>0.828944</td><td>2.170202</td><td>3</td><td>0.150085</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (2_000, 6)\n",
-       "┌───────────┬───────────┬───────────┬───────────┬───────┬────────────────┐\n",
-       "│ x1        ┆ x2        ┆ x3        ┆ y         ┆ group ┆ sample_weights │\n",
-       "│ ---       ┆ ---       ┆ ---       ┆ ---       ┆ ---   ┆ ---            │\n",
-       "│ f64       ┆ f64       ┆ f64       ┆ f64       ┆ i64   ┆ f64            │\n",
-       "╞═══════════╪═══════════╪═══════════╪═══════════╪═══════╪════════════════╡\n",
-       "│ 0.244378  ┆ 0.29603   ┆ -1.591151 ┆ 1.057149  ┆ 3     ┆ 0.350132       │\n",
-       "│ 2.093035  ┆ -1.194226 ┆ 1.174871  ┆ -2.008692 ┆ 4     ┆ 0.589495       │\n",
-       "│ 0.26513   ┆ 0.254817  ┆ 1.908368  ┆ -2.423658 ┆ 0     ┆ 0.308177       │\n",
-       "│ -0.139459 ┆ 0.201641  ┆ -0.750208 ┆ 0.698626  ┆ 1     ┆ 0.378428       │\n",
-       "│ 0.230555  ┆ 1.111359  ┆ 0.229246  ┆ -1.635799 ┆ 1     ┆ 0.138395       │\n",
-       "│ …         ┆ …         ┆ …         ┆ …         ┆ …     ┆ …              │\n",
-       "│ 1.209234  ┆ -0.792829 ┆ 0.277771  ┆ -0.895549 ┆ 2     ┆ 0.965688       │\n",
-       "│ -0.172662 ┆ -2.526893 ┆ -0.527852 ┆ 3.20544   ┆ 2     ┆ 0.569951       │\n",
-       "│ 1.835942  ┆ 0.900255  ┆ 1.29236   ┆ -4.14354  ┆ 1     ┆ 0.680204       │\n",
-       "│ -1.14397  ┆ 0.672722  ┆ -0.133538 ┆ 0.618378  ┆ 3     ┆ 0.438267       │\n",
-       "│ -0.585489 ┆ -2.278198 ┆ 0.828944  ┆ 2.170202  ┆ 3     ┆ 0.150085       │\n",
-       "└───────────┴───────────┴───────────┴───────────┴───────┴────────────────┘"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "8c0702e4-ba92-4042-ab48-2044e137c52e",
    "metadata": {},
    "source": [
     "### 1. Basic Usage: OLS / WLS\n",
-    "- You can use `pls.compute_least_squares` or `least_squares.ols` from the registered namespace. They are equivalent.\n",
+    "- You can use `pls.compute_least_squares` or `least_squares.ols` from the registered namespace. They are equivalent. You need to pass (at least) a target and some features to either, see below for examples.\n",
+    "- Features can be specified in any of the following ways:\n",
+    "    - a variable number of column (string) names. E.g. `\"x1\", \"x2\", \"x3\"`\n",
+    "    - a variable number of polars expressions. E.g. `pl.col(\"x1\"), pl.col(\"x2\"), pl.col(\"x3\")`)\n",
+    "    - a wildcard / regex multi-expression. E.g. `pl.selectors.starts_with(\"x\"))`\n",
     "- Simply pass an expression producing strictly positive sample weights to `sample_weights` argument to perform WLS"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "c7748165-bc22-4c0d-98d0-a7813d211449",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-10T20:33:40.700228Z",
-     "iopub.status.busy": "2024-04-10T20:33:40.699650Z",
-     "iopub.status.idle": "2024-04-10T20:33:40.708737Z",
-     "shell.execute_reply": "2024-04-10T20:33:40.707752Z",
-     "shell.execute_reply.started": "2024-04-10T20:33:40.700194Z"
+     "iopub.execute_input": "2024-04-12T15:34:32.227140Z",
+     "iopub.status.busy": "2024-04-12T15:34:32.226879Z",
+     "iopub.status.idle": "2024-04-12T15:34:32.238677Z",
+     "shell.execute_reply": "2024-04-12T15:34:32.233393Z",
+     "shell.execute_reply.started": "2024-04-12T15:34:32.227116Z"
     }
    },
    "outputs": [],
    "source": [
     "ols_expr = pls.compute_least_squares(pl.col(\"y\"),  # target\n",
-    "                          pl.col(\"x1\"), pl.col(\"x2\"), pl.col(\"x3\"),  # features\n",
+    "                          pl.selectors.starts_with(\"x\"),  # features - can use wildcard expressions or multiple feature expressions/names\n",
     "                          mode=\"predictions\",\n",
     "                          )\n",
-    "assert str(ols_expr) == str(pl.col(\"y\").least_squares.ols(pl.col(\"x1\"), pl.col(\"x2\"), pl.col(\"x3\")))\n",
     "\n",
-    "wls_expr = pl.col(\"y\").least_squares.wls(pl.col(\"x1\"), pl.col(\"x2\"), pl.col(\"x3\"), \n",
+    "# it is equivalent to using the registered namespace\n",
+    "assert str(ols_expr) == str(pl.col(\"y\").least_squares.ols(pl.selectors.starts_with(\"x\")))\n",
+    "\n",
+    "# make WLS by adding sample weights\n",
+    "wls_expr = pl.col(\"y\").least_squares.wls(\"x1\", \"x2\", \"x3\",  # also equivalent to pl.col(\"x1\"), pl.col(\"x2\"), pl.col(\"x3\")\n",
     "                                         sample_weights=pl.col(\"sample_weights\"))"
    ]
   },
@@ -168,15 +122,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "c824074b-cecd-43ef-a8b9-bfaeb44f77ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-10T20:33:41.768994Z",
-     "iopub.status.busy": "2024-04-10T20:33:41.768277Z",
-     "iopub.status.idle": "2024-04-10T20:33:41.791212Z",
-     "shell.execute_reply": "2024-04-10T20:33:41.789620Z",
-     "shell.execute_reply.started": "2024-04-10T20:33:41.768940Z"
+     "iopub.execute_input": "2024-04-12T15:34:33.545219Z",
+     "iopub.status.busy": "2024-04-12T15:34:33.544621Z",
+     "iopub.status.idle": "2024-04-12T15:34:33.564052Z",
+     "shell.execute_reply": "2024-04-12T15:34:33.563422Z",
+     "shell.execute_reply.started": "2024-04-12T15:34:33.545183Z"
     }
    },
    "outputs": [
@@ -190,7 +144,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (10, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>x1</th><th>x2</th><th>x3</th><th>y</th><th>group</th><th>sample_weights</th><th>predictions_ols_group</th><th>predictions_ols</th><th>predictions_wls_masked</th></tr><tr><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>i64</td><td>f64</td><td>f32</td><td>f32</td><td>f32</td></tr></thead><tbody><tr><td>1.113039</td><td>0.883359</td><td>-2.527527</td><td>0.55024</td><td>2</td><td>0.699654</td><td>0.527899</td><td>0.534972</td><td>0.531683</td></tr><tr><td>-0.162361</td><td>-0.31886</td><td>0.432553</td><td>0.116105</td><td>3</td><td>0.201684</td><td>0.050201</td><td>0.047775</td><td>0.0</td></tr><tr><td>0.513537</td><td>0.290477</td><td>1.275113</td><td>-2.125898</td><td>0</td><td>0.250123</td><td>-2.087187</td><td>-2.080451</td><td>-0.0</td></tr><tr><td>-0.409181</td><td>0.795874</td><td>-1.508068</td><td>1.218333</td><td>1</td><td>0.252079</td><td>1.120106</td><td>1.1244</td><td>0.0</td></tr><tr><td>-1.503989</td><td>-1.071248</td><td>-1.820427</td><td>4.540995</td><td>3</td><td>0.844558</td><td>4.396885</td><td>4.396938</td><td>0.0</td></tr><tr><td>1.209234</td><td>-0.792829</td><td>0.277771</td><td>-0.895549</td><td>2</td><td>0.965688</td><td>-0.688014</td><td>-0.695993</td><td>-0.698428</td></tr><tr><td>-0.172662</td><td>-2.526893</td><td>-0.527852</td><td>3.20544</td><td>2</td><td>0.569951</td><td>3.232339</td><td>3.224712</td><td>3.225684</td></tr><tr><td>1.835942</td><td>0.900255</td><td>1.29236</td><td>-4.14354</td><td>1</td><td>0.680204</td><td>-4.027004</td><td>-4.029541</td><td>-0.0</td></tr><tr><td>-1.14397</td><td>0.672722</td><td>-0.133538</td><td>0.618378</td><td>3</td><td>0.438267</td><td>0.605977</td><td>0.606245</td><td>0.0</td></tr><tr><td>-0.585489</td><td>-2.278198</td><td>0.828944</td><td>2.170202</td><td>3</td><td>0.150085</td><td>2.040467</td><td>2.030892</td><td>0.0</td></tr></tbody></table></div>"
+       "<small>shape: (10, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>x1</th><th>x2</th><th>x3</th><th>y</th><th>group</th><th>sample_weights</th><th>predictions_ols_group</th><th>predictions_ols</th><th>predictions_wls_masked</th></tr><tr><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>i64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>-0.583369</td><td>0.890726</td><td>0.497755</td><td>-0.70099</td><td>2</td><td>0.871927</td><td>-0.800004</td><td>-0.802822</td><td>-0.800443</td></tr><tr><td>0.71304</td><td>1.751887</td><td>-0.223204</td><td>-2.230821</td><td>3</td><td>0.776195</td><td>-2.241771</td><td>-2.239055</td><td>-0.0</td></tr><tr><td>1.098849</td><td>0.463944</td><td>-0.451817</td><td>-1.116165</td><td>2</td><td>0.01473</td><td>-1.111206</td><td>-1.110725</td><td>-1.11138</td></tr><tr><td>-0.485594</td><td>-0.315542</td><td>0.096269</td><td>0.866697</td><td>0</td><td>0.507687</td><td>0.70668</td><td>0.704341</td><td>0.0</td></tr><tr><td>0.949438</td><td>1.029228</td><td>0.318868</td><td>-2.197234</td><td>4</td><td>0.062403</td><td>-2.295554</td><td>-2.294688</td><td>-0.0</td></tr><tr><td>1.057735</td><td>0.268385</td><td>0.350553</td><td>-1.559323</td><td>3</td><td>0.559756</td><td>-1.67483</td><td>-1.674932</td><td>-0.0</td></tr><tr><td>-0.122949</td><td>2.002523</td><td>1.63392</td><td>-3.658936</td><td>3</td><td>0.585527</td><td>-3.503794</td><td>-3.506601</td><td>-0.0</td></tr><tr><td>-0.491295</td><td>0.870951</td><td>0.24026</td><td>-0.552929</td><td>4</td><td>0.367483</td><td>-0.617277</td><td>-0.6182</td><td>-0.0</td></tr><tr><td>-0.226812</td><td>0.740164</td><td>0.180547</td><td>-0.599317</td><td>4</td><td>0.119438</td><td>-0.691848</td><td>-0.692402</td><td>-0.0</td></tr><tr><td>0.159845</td><td>-0.226334</td><td>-0.093559</td><td>0.203998</td><td>2</td><td>0.082505</td><td>0.15888</td><td>0.159546</td><td>0.158951</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (10, 9)\n",
@@ -198,24 +152,24 @@
        "│ x1        ┆ x2        ┆ x3        ┆ y         ┆ … ┆ sample_we ┆ predictio ┆ predictio ┆ predicti │\n",
        "│ ---       ┆ ---       ┆ ---       ┆ ---       ┆   ┆ ights     ┆ ns_ols_gr ┆ ns_ols    ┆ ons_wls_ │\n",
        "│ f64       ┆ f64       ┆ f64       ┆ f64       ┆   ┆ ---       ┆ oup       ┆ ---       ┆ masked   │\n",
-       "│           ┆           ┆           ┆           ┆   ┆ f64       ┆ ---       ┆ f32       ┆ ---      │\n",
-       "│           ┆           ┆           ┆           ┆   ┆           ┆ f32       ┆           ┆ f32      │\n",
+       "│           ┆           ┆           ┆           ┆   ┆ f64       ┆ ---       ┆ f64       ┆ ---      │\n",
+       "│           ┆           ┆           ┆           ┆   ┆           ┆ f64       ┆           ┆ f64      │\n",
        "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡\n",
-       "│ 1.113039  ┆ 0.883359  ┆ -2.527527 ┆ 0.55024   ┆ … ┆ 0.699654  ┆ 0.527899  ┆ 0.534972  ┆ 0.531683 │\n",
-       "│ -0.162361 ┆ -0.31886  ┆ 0.432553  ┆ 0.116105  ┆ … ┆ 0.201684  ┆ 0.050201  ┆ 0.047775  ┆ 0.0      │\n",
-       "│ 0.513537  ┆ 0.290477  ┆ 1.275113  ┆ -2.125898 ┆ … ┆ 0.250123  ┆ -2.087187 ┆ -2.080451 ┆ -0.0     │\n",
-       "│ -0.409181 ┆ 0.795874  ┆ -1.508068 ┆ 1.218333  ┆ … ┆ 0.252079  ┆ 1.120106  ┆ 1.1244    ┆ 0.0      │\n",
-       "│ -1.503989 ┆ -1.071248 ┆ -1.820427 ┆ 4.540995  ┆ … ┆ 0.844558  ┆ 4.396885  ┆ 4.396938  ┆ 0.0      │\n",
-       "│ 1.209234  ┆ -0.792829 ┆ 0.277771  ┆ -0.895549 ┆ … ┆ 0.965688  ┆ -0.688014 ┆ -0.695993 ┆ -0.69842 │\n",
-       "│           ┆           ┆           ┆           ┆   ┆           ┆           ┆           ┆ 8        │\n",
-       "│ -0.172662 ┆ -2.526893 ┆ -0.527852 ┆ 3.20544   ┆ … ┆ 0.569951  ┆ 3.232339  ┆ 3.224712  ┆ 3.225684 │\n",
-       "│ 1.835942  ┆ 0.900255  ┆ 1.29236   ┆ -4.14354  ┆ … ┆ 0.680204  ┆ -4.027004 ┆ -4.029541 ┆ -0.0     │\n",
-       "│ -1.14397  ┆ 0.672722  ┆ -0.133538 ┆ 0.618378  ┆ … ┆ 0.438267  ┆ 0.605977  ┆ 0.606245  ┆ 0.0      │\n",
-       "│ -0.585489 ┆ -2.278198 ┆ 0.828944  ┆ 2.170202  ┆ … ┆ 0.150085  ┆ 2.040467  ┆ 2.030892  ┆ 0.0      │\n",
+       "│ -0.583369 ┆ 0.890726  ┆ 0.497755  ┆ -0.70099  ┆ … ┆ 0.871927  ┆ -0.800004 ┆ -0.802822 ┆ -0.80044 │\n",
+       "│           ┆           ┆           ┆           ┆   ┆           ┆           ┆           ┆ 3        │\n",
+       "│ 0.71304   ┆ 1.751887  ┆ -0.223204 ┆ -2.230821 ┆ … ┆ 0.776195  ┆ -2.241771 ┆ -2.239055 ┆ -0.0     │\n",
+       "│ 1.098849  ┆ 0.463944  ┆ -0.451817 ┆ -1.116165 ┆ … ┆ 0.01473   ┆ -1.111206 ┆ -1.110725 ┆ -1.11138 │\n",
+       "│ -0.485594 ┆ -0.315542 ┆ 0.096269  ┆ 0.866697  ┆ … ┆ 0.507687  ┆ 0.70668   ┆ 0.704341  ┆ 0.0      │\n",
+       "│ 0.949438  ┆ 1.029228  ┆ 0.318868  ┆ -2.197234 ┆ … ┆ 0.062403  ┆ -2.295554 ┆ -2.294688 ┆ -0.0     │\n",
+       "│ 1.057735  ┆ 0.268385  ┆ 0.350553  ┆ -1.559323 ┆ … ┆ 0.559756  ┆ -1.67483  ┆ -1.674932 ┆ -0.0     │\n",
+       "│ -0.122949 ┆ 2.002523  ┆ 1.63392   ┆ -3.658936 ┆ … ┆ 0.585527  ┆ -3.503794 ┆ -3.506601 ┆ -0.0     │\n",
+       "│ -0.491295 ┆ 0.870951  ┆ 0.24026   ┆ -0.552929 ┆ … ┆ 0.367483  ┆ -0.617277 ┆ -0.6182   ┆ -0.0     │\n",
+       "│ -0.226812 ┆ 0.740164  ┆ 0.180547  ┆ -0.599317 ┆ … ┆ 0.119438  ┆ -0.691848 ┆ -0.692402 ┆ -0.0     │\n",
+       "│ 0.159845  ┆ -0.226334 ┆ -0.093559 ┆ 0.203998  ┆ … ┆ 0.082505  ┆ 0.15888   ┆ 0.159546  ┆ 0.158951 │\n",
        "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -238,48 +192,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "223fdff7-3242-4fdf-b732-570cd07a5b0a",
+   "execution_count": null,
+   "id": "3948c48d-e429-4ba2-b9fd-0f01b94b1588",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# .struct.rename_fields([f.meta.output_name() for f in features])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "1b64f340-d8bc-493d-906f-e2cd30fa1ce6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-10T20:33:43.129500Z",
-     "iopub.status.busy": "2024-04-10T20:33:43.128910Z",
-     "iopub.status.idle": "2024-04-10T20:33:43.141833Z",
-     "shell.execute_reply": "2024-04-10T20:33:43.141266Z",
-     "shell.execute_reply.started": "2024-04-10T20:33:43.129466Z"
+     "iopub.execute_input": "2024-04-12T15:40:43.874642Z",
+     "iopub.status.busy": "2024-04-12T15:40:43.873990Z",
+     "iopub.status.idle": "2024-04-12T15:40:43.882018Z",
+     "shell.execute_reply": "2024-04-12T15:40:43.881356Z",
+     "shell.execute_reply.started": "2024-04-12T15:40:43.874608Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (1, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>coefficients</th></tr><tr><td>struct[3]</td></tr></thead><tbody><tr><td>{-0.999718,-1.029042,-0.013478}</td></tr></tbody></table></div>"
-      ],
       "text/plain": [
-       "shape: (1, 1)\n",
-       "┌─────────────────────────────────┐\n",
-       "│ coefficients                    │\n",
-       "│ ---                             │\n",
-       "│ struct[3]                       │\n",
-       "╞═════════════════════════════════╡\n",
-       "│ {-0.999718,-1.029042,-0.013478} │\n",
-       "└─────────────────────────────────┘"
+       "['x1', 'x2', 'x3', 'const']"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df.select(pl.col(\"y\").least_squares.ols(pl.col(\"x1\"), pl.col(\"x2\"), add_intercept=True, mode=\"coefficients\")\n",
+    "cc[\"coefficients\"].struct.fields"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "8b14b8ac-c34c-449c-a109-5198ee01e06e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-12T15:38:40.880009Z",
+     "iopub.status.busy": "2024-04-12T15:38:40.879453Z",
+     "iopub.status.idle": "2024-04-12T15:38:40.888887Z",
+     "shell.execute_reply": "2024-04-12T15:38:40.887726Z",
+     "shell.execute_reply.started": "2024-04-12T15:38:40.879975Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "cc = df.select(pl.col(\"y\").least_squares.ols(pl.selectors.starts_with(\"x\"), add_intercept=True, mode=\"coefficients\")\n",
     "          .alias(\"coefficients\"))"
    ]
   },
@@ -295,52 +260,72 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "4271adf2-6cb4-46ee-90c7-4e1ac1d28d93",
+   "execution_count": 11,
+   "id": "fb069a03-b026-4857-84f0-849beef178b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-10T20:33:44.616142Z",
-     "iopub.status.busy": "2024-04-10T20:33:44.615544Z",
-     "iopub.status.idle": "2024-04-10T20:33:44.628007Z",
-     "shell.execute_reply": "2024-04-10T20:33:44.627002Z",
-     "shell.execute_reply.started": "2024-04-10T20:33:44.616107Z"
+     "iopub.execute_input": "2024-04-12T15:34:59.272948Z",
+     "iopub.status.busy": "2024-04-12T15:34:59.272317Z",
+     "iopub.status.idle": "2024-04-12T15:34:59.281697Z",
+     "shell.execute_reply": "2024-04-12T15:34:59.280783Z",
+     "shell.execute_reply.started": "2024-04-12T15:34:59.272912Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
+     "data": {
+      "text/plain": [
+       "'y'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pl.col(\"y\").over(\"group\").meta.output_name()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4271adf2-6cb4-46ee-90c7-4e1ac1d28d93",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-12T15:34:35.803055Z",
+     "iopub.status.busy": "2024-04-12T15:34:35.802394Z",
+     "iopub.status.idle": "2024-04-12T15:34:36.238818Z",
+     "shell.execute_reply": "2024-04-12T15:34:36.238204Z",
+     "shell.execute_reply.started": "2024-04-12T15:34:35.802999Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "shape: (5, 2)\n",
-      "┌───────┬─────────────────────────────────┐\n",
-      "│ group ┆ coefficients                    │\n",
-      "│ ---   ┆ ---                             │\n",
-      "│ i64   ┆ struct[3]                       │\n",
-      "╞═══════╪═════════════════════════════════╡\n",
-      "│ 3     ┆ {-0.995489,-0.984824,-0.01902}  │\n",
-      "│ 4     ┆ {-1.040719,-0.995801,-0.026311} │\n",
-      "│ 0     ┆ {-0.9619,-1.095804,-0.007966}   │\n",
-      "│ 1     ┆ {-0.96268,-1.037212,-0.027022}  │\n",
-      "│ 1     ┆ {-0.96268,-1.037212,-0.027022}  │\n",
-      "└───────┴─────────────────────────────────┘\n",
-      "shape: (5, 4)\n",
-      "┌───────┬───────────┬───────────┬───────────┐\n",
-      "│ group ┆ x1        ┆ x2        ┆ const     │\n",
-      "│ ---   ┆ ---       ┆ ---       ┆ ---       │\n",
-      "│ i64   ┆ f32       ┆ f32       ┆ f32       │\n",
-      "╞═══════╪═══════════╪═══════════╪═══════════╡\n",
-      "│ 3     ┆ -0.995489 ┆ -0.984824 ┆ -0.01902  │\n",
-      "│ 4     ┆ -1.040719 ┆ -0.995801 ┆ -0.026311 │\n",
-      "│ 0     ┆ -0.9619   ┆ -1.095804 ┆ -0.007966 │\n",
-      "│ 1     ┆ -0.96268  ┆ -1.037212 ┆ -0.027022 │\n",
-      "│ 1     ┆ -0.96268  ┆ -1.037212 ┆ -0.027022 │\n",
-      "└───────┴───────────┴───────────┴───────────┘\n"
+      "panicked at src/expressions.rs:111:6:\n",
+      "called `Result::unwrap()` on an `Err` value: Duplicate(ErrString(\"column with name '' has more than one occurrences\"))\n"
+     ]
+    },
+    {
+     "ename": "ComputeError",
+     "evalue": "the plugin panicked\n\nThe message is suppressed. Set POLARS_VERBOSE=1 to send the panic message to stderr.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mComputeError\u001b[0m                              Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[7], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m df_coefficients \u001b[38;5;241m=\u001b[39m \u001b[43mdf\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mselect\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mgroup\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpl\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcol\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43my\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mleast_squares\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mols\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m      2\u001b[0m \u001b[43m   \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mx1\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mx2\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mx3\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43madd_intercept\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmode\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mcoefficients\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mover\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mgroup\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      3\u001b[0m \u001b[43m          \u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43malias\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mcoefficients\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28mprint\u001b[39m(df_coefficients\u001b[38;5;241m.\u001b[39mhead())\n\u001b[1;32m      5\u001b[0m \u001b[38;5;28mprint\u001b[39m(df_coefficients\u001b[38;5;241m.\u001b[39munnest(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mcoefficients\u001b[39m\u001b[38;5;124m\"\u001b[39m)\u001b[38;5;241m.\u001b[39mhead())\n",
+      "File \u001b[0;32m~/projects/polars_ols/venv/lib/python3.10/site-packages/polars/dataframe/frame.py:8124\u001b[0m, in \u001b[0;36mDataFrame.select\u001b[0;34m(self, *exprs, **named_exprs)\u001b[0m\n\u001b[1;32m   8024\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mselect\u001b[39m(\n\u001b[1;32m   8025\u001b[0m     \u001b[38;5;28mself\u001b[39m, \u001b[38;5;241m*\u001b[39mexprs: IntoExpr \u001b[38;5;241m|\u001b[39m Iterable[IntoExpr], \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mnamed_exprs: IntoExpr\n\u001b[1;32m   8026\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m DataFrame:\n\u001b[1;32m   8027\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   8028\u001b[0m \u001b[38;5;124;03m    Select columns from this DataFrame.\u001b[39;00m\n\u001b[1;32m   8029\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   8122\u001b[0m \u001b[38;5;124;03m    └───────────┘\u001b[39;00m\n\u001b[1;32m   8123\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 8124\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlazy\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mselect\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mexprs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mnamed_exprs\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcollect\u001b[49m\u001b[43m(\u001b[49m\u001b[43m_eager\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/projects/polars_ols/venv/lib/python3.10/site-packages/polars/lazyframe/frame.py:1943\u001b[0m, in \u001b[0;36mLazyFrame.collect\u001b[0;34m(self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, no_optimization, streaming, background, _eager)\u001b[0m\n\u001b[1;32m   1940\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m background:\n\u001b[1;32m   1941\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m InProcessQuery(ldf\u001b[38;5;241m.\u001b[39mcollect_concurrently())\n\u001b[0;32m-> 1943\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m wrap_df(\u001b[43mldf\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcollect\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m)\n",
+      "\u001b[0;31mComputeError\u001b[0m: the plugin panicked\n\nThe message is suppressed. Set POLARS_VERBOSE=1 to send the panic message to stderr."
      ]
     }
    ],
    "source": [
     "df_coefficients = df.select(\"group\", pl.col(\"y\").least_squares.ols(\n",
-    "    pl.col(\"x1\"), pl.col(\"x2\"), add_intercept=True, mode=\"coefficients\").over(\"group\")\n",
+    "   \"x1\", \"x2\", \"x3\", add_intercept=True, mode=\"coefficients\").over(\"group\")\n",
     "          .alias(\"coefficients\"))\n",
     "print(df_coefficients.head())\n",
     "print(df_coefficients.unnest(\"coefficients\").head())"
@@ -799,8 +784,150 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
+   "id": "d1d58b93-446d-431d-a537-c8e9d20d53c4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-12T16:18:04.167518Z",
+     "iopub.status.busy": "2024-04-12T16:18:04.166964Z",
+     "iopub.status.idle": "2024-04-12T16:18:04.172328Z",
+     "shell.execute_reply": "2024-04-12T16:18:04.171469Z",
+     "shell.execute_reply.started": "2024-04-12T16:18:04.167485Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from polars_ols.least_squares import convert_series_to_struct"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
    "id": "f0d9b6e8-e205-468f-b071-f5f9b276c2ca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-12T16:18:46.975433Z",
+     "iopub.status.busy": "2024-04-12T16:18:46.974941Z",
+     "iopub.status.idle": "2024-04-12T16:18:46.990354Z",
+     "shell.execute_reply": "2024-04-12T16:18:46.989635Z",
+     "shell.execute_reply.started": "2024-04-12T16:18:46.975399Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "field_name=\"x1\"\n",
+      "field_name=\"x2\"\n",
+      "series_name=\"x1\"\n",
+      "series_name=\"x2\"\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (10, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>x1</th></tr><tr><td>struct[2]</td></tr></thead><tbody><tr><td>{0.72,0.24}</td></tr><tr><td>{-2.43,0.18}</td></tr><tr><td>{-0.63,-0.95}</td></tr><tr><td>{0.05,0.23}</td></tr><tr><td>{-0.07,0.44}</td></tr><tr><td>{0.65,1.01}</td></tr><tr><td>{-0.02,-2.08}</td></tr><tr><td>{-1.64,-1.36}</td></tr><tr><td>{-0.92,0.01}</td></tr><tr><td>{-0.27,0.75}</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (10, 1)\n",
+       "┌───────────────┐\n",
+       "│ x1            │\n",
+       "│ ---           │\n",
+       "│ struct[2]     │\n",
+       "╞═══════════════╡\n",
+       "│ {0.72,0.24}   │\n",
+       "│ {-2.43,0.18}  │\n",
+       "│ {-0.63,-0.95} │\n",
+       "│ {0.05,0.23}   │\n",
+       "│ {-0.07,0.44}  │\n",
+       "│ {0.65,1.01}   │\n",
+       "│ {-0.02,-2.08} │\n",
+       "│ {-1.64,-1.36} │\n",
+       "│ {-0.92,0.01}  │\n",
+       "│ {-0.27,0.75}  │\n",
+       "└───────────────┘"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pl.DataFrame({\"y\": [1.16, -2.16, -1.57, 0.21, 0.22, 1.6, -2.11, -2.92, -0.86, 0.47],\n",
+    "                   \"x1\": [0.72, -2.43, -0.63, 0.05, -0.07, 0.65, -0.02, -1.64, -0.92, -0.27],\n",
+    "                   \"x2\": [0.24, 0.18, -0.95, 0.23, 0.44, 1.01, -2.08, -1.36, 0.01, 0.75],\n",
+    "                   \"group\": [1, 1, 1, 1, 1, 2, 2, 2, 2, 2],\n",
+    "                   \"weights\": [0.34, 0.97, 0.39, 0.8, 0.57, 0.41, 0.19, 0.87, 0.06, 0.34],\n",
+    "                   })\n",
+    "df.select(convert_series_to_struct(pl.col(\"x1\"), pl.col(\"x2\")))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "c473f320-dc5a-4119-8cfd-14a133ace4ae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-12T16:22:46.433399Z",
+     "iopub.status.busy": "2024-04-12T16:22:46.432530Z",
+     "iopub.status.idle": "2024-04-12T16:22:46.474534Z",
+     "shell.execute_reply": "2024-04-12T16:22:46.473552Z",
+     "shell.execute_reply.started": "2024-04-12T16:22:46.433354Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "field_name=\"x1\"\n",
+      "field_name=\"x2\"\n",
+      "field_name=\"x1\"\n",
+      "field_name=\"x2\"\n",
+      "series_name=\"\"\n",
+      "series_name=\"\"\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "panicked at src/expressions.rs:562:46:\n",
+      "called `Result::unwrap()` on an `Err` value: Duplicate(ErrString(\"column with name '' has more than one occurrences\"))\n"
+     ]
+    },
+    {
+     "ename": "ComputeError",
+     "evalue": "the plugin panicked\n\nThe message is suppressed. Set POLARS_VERBOSE=1 to send the panic message to stderr.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mComputeError\u001b[0m                              Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[15], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mdf\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mselect\u001b[49m\u001b[43m(\u001b[49m\u001b[43mconvert_series_to_struct\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpl\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcol\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mx1\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpl\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcol\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mx2\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mover\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mgroup\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/projects/polars_ols/venv/lib/python3.10/site-packages/polars/dataframe/frame.py:8124\u001b[0m, in \u001b[0;36mDataFrame.select\u001b[0;34m(self, *exprs, **named_exprs)\u001b[0m\n\u001b[1;32m   8024\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mselect\u001b[39m(\n\u001b[1;32m   8025\u001b[0m     \u001b[38;5;28mself\u001b[39m, \u001b[38;5;241m*\u001b[39mexprs: IntoExpr \u001b[38;5;241m|\u001b[39m Iterable[IntoExpr], \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mnamed_exprs: IntoExpr\n\u001b[1;32m   8026\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m DataFrame:\n\u001b[1;32m   8027\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   8028\u001b[0m \u001b[38;5;124;03m    Select columns from this DataFrame.\u001b[39;00m\n\u001b[1;32m   8029\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   8122\u001b[0m \u001b[38;5;124;03m    └───────────┘\u001b[39;00m\n\u001b[1;32m   8123\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 8124\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlazy\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mselect\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mexprs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mnamed_exprs\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcollect\u001b[49m\u001b[43m(\u001b[49m\u001b[43m_eager\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/projects/polars_ols/venv/lib/python3.10/site-packages/polars/lazyframe/frame.py:1943\u001b[0m, in \u001b[0;36mLazyFrame.collect\u001b[0;34m(self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, no_optimization, streaming, background, _eager)\u001b[0m\n\u001b[1;32m   1940\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m background:\n\u001b[1;32m   1941\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m InProcessQuery(ldf\u001b[38;5;241m.\u001b[39mcollect_concurrently())\n\u001b[0;32m-> 1943\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m wrap_df(\u001b[43mldf\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcollect\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m)\n",
+      "\u001b[0;31mComputeError\u001b[0m: the plugin panicked\n\nThe message is suppressed. Set POLARS_VERBOSE=1 to send the panic message to stderr."
+     ]
+    }
+   ],
+   "source": [
+    "df.select(convert_series_to_struct(pl.col(\"x1\"), pl.col(\"x2\")).over(\"group\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce7f611f-5fe5-4389-ae03-482d0cd1e5e0",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/least_squares.rs
+++ b/src/least_squares.rs
@@ -359,6 +359,7 @@ impl RecursiveLeastSquares {
 ///                                 matrix of the state estimation. Default value is 10.0.
 /// * `initial_state_mean` - An optional parameter representing the initial mean vector of the
 ///                           state estimation. If not provided, it is initialized to zeros.
+/// * `is_valid` - A slice of booleans indicating if each sample is valid.
 ///
 /// # Returns
 /// A two-dimensional array containing the updated coefficients of the linear regression model.
@@ -479,6 +480,7 @@ pub fn update_xtx_inv(
 ///                   required to calculate coefficients. If not provided, it defaults to 1.
 /// * `use_woodbury` - An optional parameter specifying whether to use Woodbury matrix identity
 ///                    which propagates inv(XTX) directly. If not provided, it defaults to `false`.
+/// * `alpha` - An optional L2 regularization parameter. Defaults to 0.
 ///
 pub fn solve_rolling_ols(
     y: &Array1<f64>,

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -12,8 +12,8 @@ from polars_ols.least_squares import SolveMethod
 
 
 def _make_data(n_samples: int = 2_000, n_features: int = 5) -> pl.DataFrame:
-    x = np.random.normal(size=(n_samples, n_features)).astype("float32")
-    eps = np.random.normal(size=n_samples, scale=0.1).astype("float32")
+    x = np.random.normal(size=(n_samples, n_features))
+    eps = np.random.normal(size=n_samples, scale=0.1)
     return pl.DataFrame(data=x, schema=[f"x{i + 1}" for i in range(n_features)]).with_columns(
         y=pl.lit(x.sum(1) + eps)
     )
@@ -192,21 +192,21 @@ if __name__ == "__main__":
     runner.bench_func("benchmark_recursive_least_squares", benchmark_recursive_least_squares, df)
     runner.bench_func("benchmark_rolling_least_squares", benchmark_rolling_least_squares, df)
 
-    # runner.bench_func("benchmark_least_squares_numpy_qr", benchmark_least_squares_numpy_qr, df)
-    # runner.bench_func("benchmark_least_squares_numpy_svd", benchmark_least_squares_numpy_svd, df)
-    # runner.bench_func("benchmark_ridge_sklearn_cholesky", benchmark_ridge_sklearn, df, "cholesky")
-    # runner.bench_func("benchmark_ridge_sklearn_svd", benchmark_ridge_sklearn, df, "svd")
-    # runner.bench_func(
-    #     "benchmark_wls_from_formula_statsmodels", benchmark_wls_from_formula_statsmodels, df
-    # )
-    # runner.bench_func("benchmark_elastic_net_sklearn", benchmark_elastic_net_sklearn, df)
-    # runner.bench_func(
-    #     "benchmark_recursive_least_squares_statsmodels",
-    #     benchmark_recursive_least_squares_statsmodels,
-    #     df,
-    # )
-    # runner.bench_func(
-    #     "benchmark_rolling_least_squares_statsmodels",
-    #     benchmark_rolling_least_squares_statsmodels,
-    #     df,
-    # )
+    runner.bench_func("benchmark_least_squares_numpy_qr", benchmark_least_squares_numpy_qr, df)
+    runner.bench_func("benchmark_least_squares_numpy_svd", benchmark_least_squares_numpy_svd, df)
+    runner.bench_func("benchmark_ridge_sklearn_cholesky", benchmark_ridge_sklearn, df, "cholesky")
+    runner.bench_func("benchmark_ridge_sklearn_svd", benchmark_ridge_sklearn, df, "svd")
+    runner.bench_func(
+        "benchmark_wls_from_formula_statsmodels", benchmark_wls_from_formula_statsmodels, df
+    )
+    runner.bench_func("benchmark_elastic_net_sklearn", benchmark_elastic_net_sklearn, df)
+    runner.bench_func(
+        "benchmark_recursive_least_squares_statsmodels",
+        benchmark_recursive_least_squares_statsmodels,
+        df,
+    )
+    runner.bench_func(
+        "benchmark_rolling_least_squares_statsmodels",
+        benchmark_rolling_least_squares_statsmodels,
+        df,
+    )


### PR DESCRIPTION
This PR speeds up runtime by reducing overhead in python layer, specifically: 

- no unnecessary WLS weighting multiplications happen unless user has provided sample weights (it was multiplying expression by 1 implicitly before, which I assumed polars query engine cancelled - but it didn't causing some delay)
- All casting to float64 happens in rust instead of python: it is faster to do there
- refactors code-paths in least_squares.py to minimize duplication (cosmetic)
- documents  https://github.com/pola-rs/pyo3-polars/issues/79 which, once resolved, will allow relying fully on rust layer to label struct output for mode="coefficients"
