### PR TITLE
fix demo notebook, bump version, improve typing. Release v0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["profile-rustflags"]
 
 [package]
 name = "polars_ols"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [lib]

--- a/notebooks/polars_ols_demo.ipynb
+++ b/notebooks/polars_ols_demo.ipynb
@@ -2,21 +2,20 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "id": "8d7bae54-e858-410c-a574-da1aa325d90a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-12T16:17:09.795316Z",
-     "iopub.status.busy": "2024-04-12T16:17:09.794504Z",
-     "iopub.status.idle": "2024-04-12T16:17:09.803346Z",
-     "shell.execute_reply": "2024-04-12T16:17:09.802625Z",
-     "shell.execute_reply.started": "2024-04-12T16:17:09.795259Z"
+     "iopub.execute_input": "2024-04-22T17:52:52.460965Z",
+     "iopub.status.busy": "2024-04-22T17:52:52.460792Z",
+     "iopub.status.idle": "2024-04-22T17:52:52.551749Z",
+     "shell.execute_reply": "2024-04-22T17:52:52.551071Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:52.460951Z"
     }
    },
    "outputs": [],
    "source": [
     "import os; os.environ[\"POLARS_VERBOSE\"] = \"1\"\n",
-    "\n",
     "import polars as pl\n",
     "import polars_ols as pls\n",
     "import numpy as np"
@@ -24,32 +23,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "id": "35076da5-137a-4d90-a671-ed1e9d650930",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-12T16:17:10.415486Z",
-     "iopub.status.busy": "2024-04-12T16:17:10.414948Z",
-     "iopub.status.idle": "2024-04-12T16:17:10.423544Z",
-     "shell.execute_reply": "2024-04-12T16:17:10.422534Z",
-     "shell.execute_reply.started": "2024-04-12T16:17:10.415447Z"
+     "iopub.execute_input": "2024-04-22T17:52:52.707925Z",
+     "iopub.status.busy": "2024-04-22T17:52:52.707584Z",
+     "iopub.status.idle": "2024-04-22T17:52:52.716339Z",
+     "shell.execute_reply": "2024-04-22T17:52:52.715460Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:52.707901Z"
     }
    },
    "outputs": [],
    "source": [
+    "rng = np.random.default_rng(0)\n",
+    "\n",
+    "def insert_nulls(val):\n",
+    "    return None if rng.random() < 0.1 else val\n",
+    "\n",
     "def _make_data(n_samples: int = 2_000, \n",
     "               n_features: int = 5,\n",
     "               n_groups: int = 5,\n",
     "               noise: float = 0.1,\n",
+    "               missing: bool = False,\n",
+    "               sparsity: float = 0.,\n",
     "              ) -> pl.DataFrame:\n",
     "    rng = np.random.default_rng(0)\n",
     "    x = rng.normal(size=(n_samples, n_features))\n",
     "    eps = rng.normal(size=n_samples, scale=noise)\n",
-    "    return pl.DataFrame(data=x, schema=[f\"x{i + 1}\" for i in range(n_features)]).with_columns(\n",
-    "        y=pl.lit(-1 * x.sum(1) + eps),\n",
+    "    df = pl.DataFrame(data=x, schema=[f\"x{i + 1}\" for i in range(n_features)]).with_columns(\n",
+    "        y=pl.lit(-1 * x[:, : int(n_features * (1.0 - sparsity))].sum(1) + eps),\n",
     "        group=pl.lit(rng.integers(0, n_groups, size=n_samples)),\n",
     "        sample_weights=pl.lit(rng.uniform(0, 1, size=n_samples)),\n",
-    "    )"
+    "    )\n",
+    "    if missing:\n",
+    "        \n",
+    "        df = df.with_columns(\n",
+    "            *(pl.col(c).map_elements(insert_nulls, return_dtype=pl.Float64) for c in df.columns)\n",
+    "        )\n",
+    "    return df"
    ]
   },
   {
@@ -58,11 +70,11 @@
    "id": "5ad1869e-d884-48e2-8f37-f790057ada1a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-12T15:34:32.207343Z",
-     "iopub.status.busy": "2024-04-12T15:34:32.205424Z",
-     "iopub.status.idle": "2024-04-12T15:34:32.225894Z",
-     "shell.execute_reply": "2024-04-12T15:34:32.223622Z",
-     "shell.execute_reply.started": "2024-04-12T15:34:32.207301Z"
+     "iopub.execute_input": "2024-04-22T17:52:53.086757Z",
+     "iopub.status.busy": "2024-04-22T17:52:53.086450Z",
+     "iopub.status.idle": "2024-04-22T17:52:53.090536Z",
+     "shell.execute_reply": "2024-04-22T17:52:53.090160Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:53.086745Z"
     }
    },
    "outputs": [],
@@ -75,41 +87,106 @@
    "id": "8c0702e4-ba92-4042-ab48-2044e137c52e",
    "metadata": {},
    "source": [
-    "### 1. Basic Usage: OLS / WLS\n",
+    "### 1. A) Basic Usage: OLS / WLS\n",
     "- You can use `pls.compute_least_squares` or `least_squares.ols` from the registered namespace. They are equivalent. You need to pass (at least) a target and some features to either, see below for examples.\n",
     "- Features can be specified in any of the following ways:\n",
     "    - a variable number of column (string) names. E.g. `\"x1\", \"x2\", \"x3\"`\n",
     "    - a variable number of polars expressions. E.g. `pl.col(\"x1\"), pl.col(\"x2\"), pl.col(\"x3\")`)\n",
-    "    - a wildcard / regex multi-expression. E.g. `pl.selectors.starts_with(\"x\"))`\n",
+    "    - a wildcard / regex multi-expression. E.g. `pl.selectors.starts_with(\"x\"))` or `pl.col(\"^x.*$\")`\n",
     "- Simply pass an expression producing strictly positive sample weights to `sample_weights` argument to perform WLS"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "f7604a81-cf0b-41ab-b39b-4cd6282797af",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:52:53.470288Z",
+     "iopub.status.busy": "2024-04-22T17:52:53.470000Z",
+     "iopub.status.idle": "2024-04-22T17:52:53.495235Z",
+     "shell.execute_reply": "2024-04-22T17:52:53.494788Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:53.470273Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mInit signature:\u001b[0m\n",
+       "\u001b[0mpls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mOLSKwargs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mnull_policy\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'NullPolicy'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'ignore'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0malpha\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'Optional[float]'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0.0\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0ml1_ratio\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'Optional[float]'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mmax_iter\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'Optional[int]'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1000\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mtol\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'Optional[float]'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1e-05\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mpositive\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'Optional[bool]'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0msolve_method\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'Optional[SolveMethod]'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mrcond\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'Optional[float]'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m     \n",
+       "Specifies parameters relevant for regularized linear models: LASSO / Ridge / ElasticNet.\n",
+       "\n",
+       "Attributes:\n",
+       "    alpha: Regularization strength. Defaults to 0.0.\n",
+       "    l1_ratio: Mixing parameter for ElasticNet regularization (0 for Ridge, 1 for LASSO).\n",
+       "        Defaults to None (equivalent to Ridge regression).\n",
+       "    max_iter: Maximum number of iterations. Defaults to 1000 iterations.\n",
+       "    tol: Tolerance for convergence criterion. Defaults to 1.e-5.\n",
+       "    positive: Whether to enforce non-negativity constraints on coefficients.\n",
+       "        Defaults to False (no constraint on coefficients).\n",
+       "    null_policy: Strategy for handling missing data. Defaults to \"ignore\".\n",
+       "    solve_method: Algorithm used for computing least squares solution.\n",
+       "        Defaults to None, where a recommended default method is chosen based on problem\n",
+       "        specifics.\n",
+       "    rcond: Optional float specifying cut-off ratio for small singular values. Only relevant for\n",
+       "           \"SVD\" solve methods. Defaults to None, where it is chosen as per\n",
+       "            numpy lstsq convention.\n",
+       "\u001b[0;31mFile:\u001b[0m           ~/projects/polars_ols/polars_ols/least_squares.py\n",
+       "\u001b[0;31mType:\u001b[0m           type\n",
+       "\u001b[0;31mSubclasses:\u001b[0m     "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# inspect OLSKwargs for details on model specific parameters\n",
+    "pls.OLSKwargs?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "id": "c7748165-bc22-4c0d-98d0-a7813d211449",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-12T15:34:32.227140Z",
-     "iopub.status.busy": "2024-04-12T15:34:32.226879Z",
-     "iopub.status.idle": "2024-04-12T15:34:32.238677Z",
-     "shell.execute_reply": "2024-04-12T15:34:32.233393Z",
-     "shell.execute_reply.started": "2024-04-12T15:34:32.227116Z"
+     "iopub.execute_input": "2024-04-22T17:52:53.638774Z",
+     "iopub.status.busy": "2024-04-22T17:52:53.638593Z",
+     "iopub.status.idle": "2024-04-22T17:52:53.643090Z",
+     "shell.execute_reply": "2024-04-22T17:52:53.642763Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:53.638761Z"
     }
    },
    "outputs": [],
    "source": [
+    "# you can use the function 'compute_least_squares'\n",
     "ols_expr = pls.compute_least_squares(pl.col(\"y\"),  # target\n",
     "                          pl.selectors.starts_with(\"x\"),  # features - can use wildcard expressions or multiple feature expressions/names\n",
     "                          mode=\"predictions\",\n",
+    "                          ols_kwargs=pls.OLSKwargs(null_policy=\"drop\", solve_method=\"svd\")\n",
     "                          )\n",
     "\n",
-    "# it is equivalent to using the registered namespace\n",
+    "# which is equivalent to using the registered namespace\n",
     "assert str(ols_expr) == str(pl.col(\"y\").least_squares.ols(pl.selectors.starts_with(\"x\")))\n",
     "\n",
-    "# make WLS by adding sample weights\n",
+    "# you can make WLS by adding sample weights\n",
     "wls_expr = pl.col(\"y\").least_squares.wls(\"x1\", \"x2\", \"x3\",  # also equivalent to pl.col(\"x1\"), pl.col(\"x2\"), pl.col(\"x3\")\n",
-    "                                         sample_weights=pl.col(\"sample_weights\"))"
+    "                                         sample_weights=pl.col(\"sample_weights\"))\n",
+    "\n",
+    "assert str(wls_expr) == str(pls.compute_least_squares(\"y\", \"x1\", \"x2\", \"x3\", sample_weights=\"sample_weights\"))"
    ]
   },
   {
@@ -122,15 +199,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "c824074b-cecd-43ef-a8b9-bfaeb44f77ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-12T15:34:33.545219Z",
-     "iopub.status.busy": "2024-04-12T15:34:33.544621Z",
-     "iopub.status.idle": "2024-04-12T15:34:33.564052Z",
-     "shell.execute_reply": "2024-04-12T15:34:33.563422Z",
-     "shell.execute_reply.started": "2024-04-12T15:34:33.545183Z"
+     "iopub.execute_input": "2024-04-22T17:52:54.087503Z",
+     "iopub.status.busy": "2024-04-22T17:52:54.087329Z",
+     "iopub.status.idle": "2024-04-22T17:52:54.100681Z",
+     "shell.execute_reply": "2024-04-22T17:52:54.100236Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:54.087488Z"
     }
    },
    "outputs": [
@@ -169,7 +246,7 @@
        "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -192,59 +269,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3948c48d-e429-4ba2-b9fd-0f01b94b1588",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# .struct.rename_fields([f.meta.output_name() for f in features])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "id": "1b64f340-d8bc-493d-906f-e2cd30fa1ce6",
+   "execution_count": 7,
+   "id": "8b14b8ac-c34c-449c-a109-5198ee01e06e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-12T15:40:43.874642Z",
-     "iopub.status.busy": "2024-04-12T15:40:43.873990Z",
-     "iopub.status.idle": "2024-04-12T15:40:43.882018Z",
-     "shell.execute_reply": "2024-04-12T15:40:43.881356Z",
-     "shell.execute_reply.started": "2024-04-12T15:40:43.874608Z"
+     "iopub.execute_input": "2024-04-22T17:52:54.626201Z",
+     "iopub.status.busy": "2024-04-22T17:52:54.625912Z",
+     "iopub.status.idle": "2024-04-22T17:52:54.652919Z",
+     "shell.execute_reply": "2024-04-22T17:52:54.652647Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:54.626177Z"
     }
    },
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (1, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>coefficients</th></tr><tr><td>struct[2]</td></tr></thead><tbody><tr><td>{-0.999496,-0.998398}</td></tr></tbody></table></div>"
+      ],
       "text/plain": [
-       "['x1', 'x2', 'x3', 'const']"
+       "shape: (1, 1)\n",
+       "┌───────────────────────┐\n",
+       "│ coefficients          │\n",
+       "│ ---                   │\n",
+       "│ struct[2]             │\n",
+       "╞═══════════════════════╡\n",
+       "│ {-0.999496,-0.998398} │\n",
+       "└───────────────────────┘"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "cc[\"coefficients\"].struct.fields"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "8b14b8ac-c34c-449c-a109-5198ee01e06e",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-04-12T15:38:40.880009Z",
-     "iopub.status.busy": "2024-04-12T15:38:40.879453Z",
-     "iopub.status.idle": "2024-04-12T15:38:40.888887Z",
-     "shell.execute_reply": "2024-04-12T15:38:40.887726Z",
-     "shell.execute_reply.started": "2024-04-12T15:38:40.879975Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "cc = df.select(pl.col(\"y\").least_squares.ols(pl.selectors.starts_with(\"x\"), add_intercept=True, mode=\"coefficients\")\n",
+    "df.select(pl.col(\"y\").least_squares.ols(pl.selectors.starts_with(\"x\"), add_intercept=True, mode=\"coefficients\")\n",
     "          .alias(\"coefficients\"))"
    ]
   },
@@ -260,66 +326,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "fb069a03-b026-4857-84f0-849beef178b6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-04-12T15:34:59.272948Z",
-     "iopub.status.busy": "2024-04-12T15:34:59.272317Z",
-     "iopub.status.idle": "2024-04-12T15:34:59.281697Z",
-     "shell.execute_reply": "2024-04-12T15:34:59.280783Z",
-     "shell.execute_reply.started": "2024-04-12T15:34:59.272912Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'y'"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pl.col(\"y\").over(\"group\").meta.output_name()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "4271adf2-6cb4-46ee-90c7-4e1ac1d28d93",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-12T15:34:35.803055Z",
-     "iopub.status.busy": "2024-04-12T15:34:35.802394Z",
-     "iopub.status.idle": "2024-04-12T15:34:36.238818Z",
-     "shell.execute_reply": "2024-04-12T15:34:36.238204Z",
-     "shell.execute_reply.started": "2024-04-12T15:34:35.802999Z"
+     "iopub.execute_input": "2024-04-22T17:52:55.093128Z",
+     "iopub.status.busy": "2024-04-22T17:52:55.092923Z",
+     "iopub.status.idle": "2024-04-22T17:52:55.099203Z",
+     "shell.execute_reply": "2024-04-22T17:52:55.098880Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:55.093108Z"
     }
    },
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "panicked at src/expressions.rs:111:6:\n",
-      "called `Result::unwrap()` on an `Err` value: Duplicate(ErrString(\"column with name '' has more than one occurrences\"))\n"
-     ]
-    },
-    {
-     "ename": "ComputeError",
-     "evalue": "the plugin panicked\n\nThe message is suppressed. Set POLARS_VERBOSE=1 to send the panic message to stderr.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mComputeError\u001b[0m                              Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[7], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m df_coefficients \u001b[38;5;241m=\u001b[39m \u001b[43mdf\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mselect\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mgroup\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpl\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcol\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43my\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mleast_squares\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mols\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m      2\u001b[0m \u001b[43m   \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mx1\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mx2\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mx3\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43madd_intercept\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmode\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mcoefficients\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mover\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mgroup\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      3\u001b[0m \u001b[43m          \u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43malias\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mcoefficients\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28mprint\u001b[39m(df_coefficients\u001b[38;5;241m.\u001b[39mhead())\n\u001b[1;32m      5\u001b[0m \u001b[38;5;28mprint\u001b[39m(df_coefficients\u001b[38;5;241m.\u001b[39munnest(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mcoefficients\u001b[39m\u001b[38;5;124m\"\u001b[39m)\u001b[38;5;241m.\u001b[39mhead())\n",
-      "File \u001b[0;32m~/projects/polars_ols/venv/lib/python3.10/site-packages/polars/dataframe/frame.py:8124\u001b[0m, in \u001b[0;36mDataFrame.select\u001b[0;34m(self, *exprs, **named_exprs)\u001b[0m\n\u001b[1;32m   8024\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mselect\u001b[39m(\n\u001b[1;32m   8025\u001b[0m     \u001b[38;5;28mself\u001b[39m, \u001b[38;5;241m*\u001b[39mexprs: IntoExpr \u001b[38;5;241m|\u001b[39m Iterable[IntoExpr], \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mnamed_exprs: IntoExpr\n\u001b[1;32m   8026\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m DataFrame:\n\u001b[1;32m   8027\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   8028\u001b[0m \u001b[38;5;124;03m    Select columns from this DataFrame.\u001b[39;00m\n\u001b[1;32m   8029\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   8122\u001b[0m \u001b[38;5;124;03m    └───────────┘\u001b[39;00m\n\u001b[1;32m   8123\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 8124\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlazy\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mselect\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mexprs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mnamed_exprs\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcollect\u001b[49m\u001b[43m(\u001b[49m\u001b[43m_eager\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/projects/polars_ols/venv/lib/python3.10/site-packages/polars/lazyframe/frame.py:1943\u001b[0m, in \u001b[0;36mLazyFrame.collect\u001b[0;34m(self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, no_optimization, streaming, background, _eager)\u001b[0m\n\u001b[1;32m   1940\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m background:\n\u001b[1;32m   1941\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m InProcessQuery(ldf\u001b[38;5;241m.\u001b[39mcollect_concurrently())\n\u001b[0;32m-> 1943\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m wrap_df(\u001b[43mldf\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcollect\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m)\n",
-      "\u001b[0;31mComputeError\u001b[0m: the plugin panicked\n\nThe message is suppressed. Set POLARS_VERBOSE=1 to send the panic message to stderr."
+      "shape: (5, 2)\n",
+      "┌───────┬───────────────────────────────────┐\n",
+      "│ group ┆ coefficients                      │\n",
+      "│ ---   ┆ ---                               │\n",
+      "│ i64   ┆ struct[4]                         │\n",
+      "╞═══════╪═══════════════════════════════════╡\n",
+      "│ 1     ┆ {-0.993655,-0.997968,-1.006029,0… │\n",
+      "│ 0     ┆ {-1.002313,-1.0001,-0.993786,-0.… │\n",
+      "│ 4     ┆ {-1.000859,-0.998017,-0.998356,0… │\n",
+      "│ 3     ┆ {-0.999962,-0.999101,-0.995044,0… │\n",
+      "│ 3     ┆ {-0.999962,-0.999101,-0.995044,0… │\n",
+      "└───────┴───────────────────────────────────┘\n",
+      "shape: (5, 5)\n",
+      "┌───────┬───────────┬───────────┬───────────┬───────────┐\n",
+      "│ group ┆ x1        ┆ x2        ┆ x3        ┆ const     │\n",
+      "│ ---   ┆ ---       ┆ ---       ┆ ---       ┆ ---       │\n",
+      "│ i64   ┆ f64       ┆ f64       ┆ f64       ┆ f64       │\n",
+      "╞═══════╪═══════════╪═══════════╪═══════════╪═══════════╡\n",
+      "│ 1     ┆ -0.993655 ┆ -0.997968 ┆ -1.006029 ┆ 0.003129  │\n",
+      "│ 0     ┆ -1.002313 ┆ -1.0001   ┆ -0.993786 ┆ -0.006384 │\n",
+      "│ 4     ┆ -1.000859 ┆ -0.998017 ┆ -0.998356 ┆ 0.004797  │\n",
+      "│ 3     ┆ -0.999962 ┆ -0.999101 ┆ -0.995044 ┆ 0.004376  │\n",
+      "│ 3     ┆ -0.999962 ┆ -0.999101 ┆ -0.995044 ┆ 0.004376  │\n",
+      "└───────┴───────────┴───────────┴───────────┴───────────┘\n"
      ]
     }
    ],
@@ -329,6 +375,575 @@
     "          .alias(\"coefficients\"))\n",
     "print(df_coefficients.head())\n",
     "print(df_coefficients.unnest(\"coefficients\").head())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "369207e6-2220-4288-b04e-197d1a3b849b",
+   "metadata": {},
+   "source": [
+    "### 1. B) Null Policy & Solve Methods\n",
+    "\n",
+    "- Most models expose a choice over multiple algorithms (\"solve_method\") and multiple strategies in handling missing data (\"null_policy\")\n",
+    "- The next section explains how some of these options work"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63426f80-c1be-4d67-b21b-64812c1bbd21",
+   "metadata": {},
+   "source": [
+    "#### Make some data with random nulls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e67f6d5f-89fe-44cb-8b8e-4d67cc8323e6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:52:55.946208Z",
+     "iopub.status.busy": "2024-04-22T17:52:55.945919Z",
+     "iopub.status.idle": "2024-04-22T17:52:56.000325Z",
+     "shell.execute_reply": "2024-04-22T17:52:55.997692Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:55.946174Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df_missing = _make_data(missing=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "92e17a52-16b5-4f0f-ae87-dbf2d0a402c1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:52:56.138821Z",
+     "iopub.status.busy": "2024-04-22T17:52:56.138659Z",
+     "iopub.status.idle": "2024-04-22T17:52:56.142457Z",
+     "shell.execute_reply": "2024-04-22T17:52:56.141989Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:56.138808Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (2_000, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>x1</th><th>x2</th><th>x3</th><th>x4</th><th>x5</th><th>y</th><th>group</th><th>sample_weights</th></tr><tr><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>0.12573</td><td>-0.132105</td><td>0.640423</td><td>0.1049</td><td>-0.535669</td><td>-0.154338</td><td>2.0</td><td>0.313882</td></tr><tr><td>0.361595</td><td>1.304</td><td>0.947081</td><td>-0.703735</td><td>null</td><td>-0.777174</td><td>1.0</td><td>0.215647</td></tr><tr><td>null</td><td>0.041326</td><td>-2.325031</td><td>null</td><td>-1.245911</td><td>4.260299</td><td>0.0</td><td>0.975329</td></tr><tr><td>null</td><td>-0.544259</td><td>-0.3163</td><td>0.411631</td><td>1.042513</td><td>0.093387</td><td>1.0</td><td>0.349839</td></tr><tr><td>-0.128535</td><td>1.366463</td><td>-0.665195</td><td>0.35151</td><td>null</td><td>-1.659732</td><td>1.0</td><td>0.180044</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>null</td><td>0.433351</td><td>null</td><td>0.659305</td><td>0.346436</td><td>null</td><td>2.0</td><td>0.921171</td></tr><tr><td>0.73432</td><td>-0.562784</td><td>0.642383</td><td>-0.328101</td><td>-0.704787</td><td>0.239824</td><td>1.0</td><td>0.930792</td></tr><tr><td>-0.880797</td><td>-0.497476</td><td>-0.464837</td><td>1.577698</td><td>0.045559</td><td>0.249027</td><td>1.0</td><td>0.120942</td></tr><tr><td>null</td><td>0.479883</td><td>null</td><td>-0.459391</td><td>null</td><td>-0.395502</td><td>2.0</td><td>0.86176</td></tr><tr><td>1.338043</td><td>null</td><td>-0.416367</td><td>-1.266301</td><td>1.031231</td><td>-0.20221</td><td>1.0</td><td>null</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (2_000, 8)\n",
+       "┌───────────┬───────────┬───────────┬───────────┬───────────┬───────────┬───────┬────────────────┐\n",
+       "│ x1        ┆ x2        ┆ x3        ┆ x4        ┆ x5        ┆ y         ┆ group ┆ sample_weights │\n",
+       "│ ---       ┆ ---       ┆ ---       ┆ ---       ┆ ---       ┆ ---       ┆ ---   ┆ ---            │\n",
+       "│ f64       ┆ f64       ┆ f64       ┆ f64       ┆ f64       ┆ f64       ┆ f64   ┆ f64            │\n",
+       "╞═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════╪════════════════╡\n",
+       "│ 0.12573   ┆ -0.132105 ┆ 0.640423  ┆ 0.1049    ┆ -0.535669 ┆ -0.154338 ┆ 2.0   ┆ 0.313882       │\n",
+       "│ 0.361595  ┆ 1.304     ┆ 0.947081  ┆ -0.703735 ┆ null      ┆ -0.777174 ┆ 1.0   ┆ 0.215647       │\n",
+       "│ null      ┆ 0.041326  ┆ -2.325031 ┆ null      ┆ -1.245911 ┆ 4.260299  ┆ 0.0   ┆ 0.975329       │\n",
+       "│ null      ┆ -0.544259 ┆ -0.3163   ┆ 0.411631  ┆ 1.042513  ┆ 0.093387  ┆ 1.0   ┆ 0.349839       │\n",
+       "│ -0.128535 ┆ 1.366463  ┆ -0.665195 ┆ 0.35151   ┆ null      ┆ -1.659732 ┆ 1.0   ┆ 0.180044       │\n",
+       "│ …         ┆ …         ┆ …         ┆ …         ┆ …         ┆ …         ┆ …     ┆ …              │\n",
+       "│ null      ┆ 0.433351  ┆ null      ┆ 0.659305  ┆ 0.346436  ┆ null      ┆ 2.0   ┆ 0.921171       │\n",
+       "│ 0.73432   ┆ -0.562784 ┆ 0.642383  ┆ -0.328101 ┆ -0.704787 ┆ 0.239824  ┆ 1.0   ┆ 0.930792       │\n",
+       "│ -0.880797 ┆ -0.497476 ┆ -0.464837 ┆ 1.577698  ┆ 0.045559  ┆ 0.249027  ┆ 1.0   ┆ 0.120942       │\n",
+       "│ null      ┆ 0.479883  ┆ null      ┆ -0.459391 ┆ null      ┆ -0.395502 ┆ 2.0   ┆ 0.86176        │\n",
+       "│ 1.338043  ┆ null      ┆ -0.416367 ┆ -1.266301 ┆ 1.031231  ┆ -0.20221  ┆ 1.0   ┆ null           │\n",
+       "└───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────┴────────────────┘"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_missing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "527c85d6-0054-44ac-a099-dcb7068b2f3f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:52:56.330351Z",
+     "iopub.status.busy": "2024-04-22T17:52:56.330133Z",
+     "iopub.status.idle": "2024-04-22T17:52:56.333519Z",
+     "shell.execute_reply": "2024-04-22T17:52:56.332947Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:56.330335Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "typing.Literal['zero', 'drop', 'ignore', 'drop_zero', 'drop_y_zero_x', 'drop_window']"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pls.NullPolicy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e23f07e6-1f98-455d-8971-ca17c69b174a",
+   "metadata": {},
+   "source": [
+    "#### i- null_policy: \"zero\": simply equivalent to zero filling prior to fitting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a4d04c0b-f464-456f-b292-c0576718ddf9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:52:56.820409Z",
+     "iopub.status.busy": "2024-04-22T17:52:56.820230Z",
+     "iopub.status.idle": "2024-04-22T17:52:56.826103Z",
+     "shell.execute_reply": "2024-04-22T17:52:56.825776Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:56.820393Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "shape: (5, 1)\n",
+      "┌───────────┐\n",
+      "│ y         │\n",
+      "│ ---       │\n",
+      "│ f64       │\n",
+      "╞═══════════╡\n",
+      "│ null      │\n",
+      "│ 0.081255  │\n",
+      "│ 0.026447  │\n",
+      "│ -0.377051 │\n",
+      "│ 0.409127  │\n",
+      "└───────────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "pred_zero = df_missing.select(\n",
+    "    pls.compute_least_squares(\"y\", pl.selectors.starts_with(\"x\"), \n",
+    "                              mode=\"predictions\",\n",
+    "                              ols_kwargs=pls.OLSKwargs(null_policy=\"zero\"))\n",
+    ")\n",
+    "\n",
+    "expected = df_missing.fill_null(0.).select(pl.col(\"y\").least_squares.ols(pl.selectors.starts_with(\"x\")))\n",
+    "\n",
+    "assert np.allclose(pred_zero, expected)\n",
+    "\n",
+    "\n",
+    "# notice that residuals, however, will keep the nulls in the original targets (resid := y - y_hat)\n",
+    "print(df_missing.select(pl.col(\"y\").least_squares.ols(\n",
+    "    pl.selectors.starts_with(\"x\"),\n",
+    "    mode=\"residuals\",\n",
+    "    null_policy=\"zero\",\n",
+    ")).tail())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8966b587-81a7-4557-9137-94f0fd7e0e68",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:03:41.813770Z",
+     "iopub.status.busy": "2024-04-22T17:03:41.812828Z",
+     "iopub.status.idle": "2024-04-22T17:03:41.823988Z",
+     "shell.execute_reply": "2024-04-22T17:03:41.823468Z",
+     "shell.execute_reply.started": "2024-04-22T17:03:41.813702Z"
+    }
+   },
+   "source": [
+    "#### ii- null_policy: \"drop\": is equivalent to dropping rows with nulls in targets or features prior to fitting\n",
+    "- but then 'broadcasting' predictions to original data shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "9a605974-3218-4dea-929d-71752577d018",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:52:57.353780Z",
+     "iopub.status.busy": "2024-04-22T17:52:57.353532Z",
+     "iopub.status.idle": "2024-04-22T17:52:57.361291Z",
+     "shell.execute_reply": "2024-04-22T17:52:57.360911Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:57.353759Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "dataframe filtered\n"
+     ]
+    }
+   ],
+   "source": [
+    "coef_drop = df_missing.select(\n",
+    "    pl.col(\"y\").least_squares.ols(\"x1\", \"x2\", \n",
+    "                              mode=\"coefficients\",\n",
+    "                              null_policy=\"drop\")\n",
+    ")\n",
+    "\n",
+    "\n",
+    "expected = df_missing.drop_nulls(subset=[\"y\", \"x1\", \"x2\"]\n",
+    "                                ).select(pl.col(\"y\").least_squares.ols(\"x1\", \"x2\", mode=\"coefficients\"))\n",
+    "\n",
+    "assert np.allclose(coef_drop.unnest(\"coefficients\"), expected.unnest(\"coefficients\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5205999d-6b2c-45f3-89d2-9d0a242d872c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:11:06.810780Z",
+     "iopub.status.busy": "2024-04-22T17:11:06.810319Z",
+     "iopub.status.idle": "2024-04-22T17:11:06.815273Z",
+     "shell.execute_reply": "2024-04-22T17:11:06.814423Z",
+     "shell.execute_reply.started": "2024-04-22T17:11:06.810754Z"
+    }
+   },
+   "source": [
+    "#### iii- null_policy: \"drop_y_zero_x\": is equivalent to masking only rows with nulls in targets\n",
+    "- and then zeroing out any remainining nulls in features prior to fitting and prediction\n",
+    "- but then 'broadcasting' predictions to original data shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "9966577c-e91f-4fdd-88c6-bd26ee2b63b8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:52:57.957569Z",
+     "iopub.status.busy": "2024-04-22T17:52:57.957371Z",
+     "iopub.status.idle": "2024-04-22T17:52:57.963563Z",
+     "shell.execute_reply": "2024-04-22T17:52:57.963259Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:57.957554Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "dataframe filtered\n"
+     ]
+    }
+   ],
+   "source": [
+    "coef_drop_y = df_missing.select(\n",
+    "    pl.col(\"y\").least_squares.ols(\"x1\", \"x2\", \n",
+    "                              mode=\"coefficients\",\n",
+    "                              null_policy=\"drop_y_zero_x\")\n",
+    ")\n",
+    "\n",
+    "expected = (\n",
+    "    df_missing.drop_nulls(subset=[\"y\"]).fill_null(0.)\n",
+    "    .select(pl.col(\"y\").least_squares.ols(\"x1\", \"x2\", mode=\"coefficients\"))\n",
+    ")\n",
+    "\n",
+    "assert np.allclose(coef_drop_y.unnest(\"coefficients\"), expected.unnest(\"coefficients\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "e1454e57-7a21-4da2-a525-233eda2c2d8b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:52:58.278029Z",
+     "iopub.status.busy": "2024-04-22T17:52:58.277781Z",
+     "iopub.status.idle": "2024-04-22T17:52:58.281106Z",
+     "shell.execute_reply": "2024-04-22T17:52:58.280662Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:58.278008Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "typing.Literal['qr', 'svd', 'chol', 'lu', 'cd', 'cd_active_set']"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pls.SolveMethod"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db3af623-5c0c-4b0c-b4b2-5b29ec555c2d",
+   "metadata": {},
+   "source": [
+    "#### Overview of Solve Methods: \n",
+    "- *\"qr\"*: Uses QR decomposition with partial pivoting to decompose 'X' into a product of a unitary and upper trapezoidal matrices. The decomposition is then used to solve least squares equations. See [here](https://docs.rs/faer-qr/latest/faer_qr/)\n",
+    "- *\"svd\"*: Uses Singular Value Decomposition (or, if on linux or macos, LAPACK accelerated divide and conquer SVD) to identify the minimum norm solution for least squares problem. This is usually the best approach for singular / multicollinear problems. See [here](https://netlib.org/lapack/explore-html-3.6.1/d7/d3b/group__double_g_esolve_ga479cdaa0d257e4e42f2fb5dcc30111b1.html).\n",
+    "- *\"chol\"*: Uses a simple cholesky decomposition of XTX and directly solves the normal equations XTX vs XTY. This approach is often the fastest but assumes well behaved data (e.g. full rank). This may be chosen as a suitable method to solve ridge problems. \n",
+    "- *\"lu\"*: Uses LU decomposition with pivoting to directly solve the normal equations\n",
+    "- *\"cd\"*: short for 'Coordinate Descent'. This approach is usesd by more complex models (which don't admit analytic solutions) and either use L1 penalty or impose non-negativity constraint on coefficients. It works by iteratively updating coefficients, one feature at a time, an approach which is very effective for elastic net type problems. See implementation [here](https://github.com/azmyrajab/polars_ols/blob/ce499a7e2f450378441421bcb1512b57a816af2c/src/least_squares.rs#L328).\n",
+    "- *\"cd_active_set\"*: For problems with large number of features and high degree of expected sparsity, we know that most coefficients will be zero. In such problems, cyclic coordinate descent can be accelerated by 'turning off' coefficients which have converged to zero and focusing remaining iterations on non-zero features."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7dcab8ae-0a19-40b6-80e4-62b69909775a",
+   "metadata": {},
+   "source": [
+    "### Example: solve_method: \"svd\" to recover minimum norm solution in presence of multi-collinearity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "2ab3d26e-aaea-4869-9a4d-393288409f7d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:52:59.297817Z",
+     "iopub.status.busy": "2024-04-22T17:52:59.297321Z",
+     "iopub.status.idle": "2024-04-22T17:52:59.304207Z",
+     "shell.execute_reply": "2024-04-22T17:52:59.303417Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:59.297797Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df_collinear = (\n",
+    "    df\n",
+    "    .select(\"x1\", \"x2\", \"x3\")\n",
+    "    .with_columns(pl.col(\"x2\").alias(\"x3\"))  # I add a totally collinear feature x3 which is a copy of x2\n",
+    "    .with_columns(pl.sum_horizontal(pl.col(\"^x.*$\")).alias(\"y\"))  # y is the sum of x1, .., x3 \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "109d9e56-ec0c-4bd5-bd35-75fde2aa88fa",
+   "metadata": {},
+   "source": [
+    "#### QR identifies a 'correct', but not minimum norm, solution (out of the infinite ones)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "ef238917-1c96-4ed0-ad6e-eca4f1bf7b34",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:52:59.916023Z",
+     "iopub.status.busy": "2024-04-22T17:52:59.915843Z",
+     "iopub.status.idle": "2024-04-22T17:52:59.920547Z",
+     "shell.execute_reply": "2024-04-22T17:52:59.920218Z",
+     "shell.execute_reply.started": "2024-04-22T17:52:59.916011Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "norm= 2.23606797749979\n",
+      "shape: (1, 1)\n",
+      "┌────────────────┐\n",
+      "│ coefficients   │\n",
+      "│ ---            │\n",
+      "│ struct[3]      │\n",
+      "╞════════════════╡\n",
+      "│ {1.0,2.0,-0.0} │\n",
+      "└────────────────┘\n"
+     ]
+    }
+   ],
+   "source": [
+    "coef_qr = df_collinear.select(pl.col(\"y\").least_squares.ols(\"x1\", \"x2\", \"x3\", solve_method=\"qr\", mode=\"coefficients\"))\n",
+    "print(\"norm=\",np.linalg.norm(coef_qr.unnest(\"coefficients\")))\n",
+    "print(coef_qr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e786b4f-6074-45b4-8e9a-520ed7c3bf75",
+   "metadata": {},
+   "source": [
+    "#### Cholesky fails to compute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "76ae5386-d457-48e1-847a-ff31b881bf61",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:53:00.579546Z",
+     "iopub.status.busy": "2024-04-22T17:53:00.579234Z",
+     "iopub.status.idle": "2024-04-22T17:53:00.585891Z",
+     "shell.execute_reply": "2024-04-22T17:53:00.585584Z",
+     "shell.execute_reply.started": "2024-04-22T17:53:00.579529Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cholesky decomposition failed, falling back to LU w/ pivoting\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (1, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>coefficients</th></tr><tr><td>struct[3]</td></tr></thead><tbody><tr><td>{null,null,null}</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (1, 1)\n",
+       "┌──────────────────┐\n",
+       "│ coefficients     │\n",
+       "│ ---              │\n",
+       "│ struct[3]        │\n",
+       "╞══════════════════╡\n",
+       "│ {null,null,null} │\n",
+       "└──────────────────┘"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_collinear.select(pl.col(\"y\").least_squares.ols(\"x1\", \"x2\", \"x3\", solve_method=\"chol\", mode=\"coefficients\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77c8c371-2810-4804-ae3c-3294245d8c74",
+   "metadata": {},
+   "source": [
+    "#### SVD computes the minimum norm solution [1, 1, 1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "943b6e4d-09b0-410a-b571-85497907eb57",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:53:01.174401Z",
+     "iopub.status.busy": "2024-04-22T17:53:01.174152Z",
+     "iopub.status.idle": "2024-04-22T17:53:01.179057Z",
+     "shell.execute_reply": "2024-04-22T17:53:01.178706Z",
+     "shell.execute_reply.started": "2024-04-22T17:53:01.174387Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (1, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>coefficients</th></tr><tr><td>struct[3]</td></tr></thead><tbody><tr><td>{1.0,1.0,1.0}</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (1, 1)\n",
+       "┌───────────────┐\n",
+       "│ coefficients  │\n",
+       "│ ---           │\n",
+       "│ struct[3]     │\n",
+       "╞═══════════════╡\n",
+       "│ {1.0,1.0,1.0} │\n",
+       "└───────────────┘"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_collinear.select(pl.col(\"y\").least_squares.ols(\"x1\", \"x2\", \"x3\", solve_method=\"svd\", mode=\"coefficients\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6391b71c-e3d1-4607-88de-abb762bffe1b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:39:37.647930Z",
+     "iopub.status.busy": "2024-04-22T17:39:37.647487Z",
+     "iopub.status.idle": "2024-04-22T17:39:37.651048Z",
+     "shell.execute_reply": "2024-04-22T17:39:37.650411Z",
+     "shell.execute_reply.started": "2024-04-22T17:39:37.647905Z"
+    }
+   },
+   "source": [
+    "#### It matches np.linalg.lstsq which uses the same algorithm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "bcb50dae-4325-46c6-a939-4bc3ec48633a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:53:02.035744Z",
+     "iopub.status.busy": "2024-04-22T17:53:02.035577Z",
+     "iopub.status.idle": "2024-04-22T17:53:02.039188Z",
+     "shell.execute_reply": "2024-04-22T17:53:02.038816Z",
+     "shell.execute_reply.started": "2024-04-22T17:53:02.035731Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([1., 1., 1.])"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.linalg.lstsq(df_collinear.select(\"x1\", \"x2\", \"x3\"), df_collinear[\"y\"], rcond=None)[0]"
    ]
   },
   {
@@ -351,71 +966,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "a9ba3765-2a42-4675-bc92-2d211bdcc03b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-04-10T20:33:45.748192Z",
-     "iopub.status.busy": "2024-04-10T20:33:45.747632Z",
-     "iopub.status.idle": "2024-04-10T20:33:45.819186Z",
-     "shell.execute_reply": "2024-04-10T20:33:45.818658Z",
-     "shell.execute_reply.started": "2024-04-10T20:33:45.748161Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mInit signature:\u001b[0m\n",
-       "\u001b[0mpls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mOLSKwargs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0malpha\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'Optional[float]'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0.0\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0ml1_ratio\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'Optional[float]'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mmax_iter\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'Optional[int]'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1000\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mtol\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'Optional[float]'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1e-05\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mpositive\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'Optional[bool]'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mnull_policy\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'NullPolicy'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'ignore'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0msolve_method\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'Optional[SolveMethod]'\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-       "\u001b[0;31mDocstring:\u001b[0m     \n",
-       "Specifies parameters relevant for regularized linear models: LASSO / Ridge / ElasticNet.\n",
-       "\n",
-       "Attributes:\n",
-       "    alpha: Regularization strength. Defaults to 0.0.\n",
-       "    l1_ratio: Mixing parameter for ElasticNet regularization (0 for Ridge, 1 for LASSO).\n",
-       "        Defaults to None (equivalent to Ridge regression).\n",
-       "    max_iter: Maximum number of iterations. Defaults to 1000 iterations.\n",
-       "    tol: Tolerance for convergence criterion. Defaults to 1.e-5.\n",
-       "    positive: Whether to enforce non-negativity constraints on coefficients.\n",
-       "        Defaults to False (no constraint on coefficients).\n",
-       "    null_policy: Strategy for handling missing data. Defaults to \"ignore\".\n",
-       "    solve_method: Algorithm used for computing least squares solution.\n",
-       "        Defaults to None, where a recommended default method is chosen based on problem\n",
-       "        specifics.\n",
-       "\u001b[0;31mFile:\u001b[0m           ~/anaconda3/envs/gem/lib/python3.10/site-packages/polars_ols/least_squares.py\n",
-       "\u001b[0;31mType:\u001b[0m           type\n",
-       "\u001b[0;31mSubclasses:\u001b[0m     "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# inspect OLS Kwargs\n",
-    "pls.OLSKwargs?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 21,
    "id": "e35fbf57-3edb-4450-bcf7-a6c2aeef1e6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-10T20:33:46.948681Z",
-     "iopub.status.busy": "2024-04-10T20:33:46.948106Z",
-     "iopub.status.idle": "2024-04-10T20:33:46.964983Z",
-     "shell.execute_reply": "2024-04-10T20:33:46.964295Z",
-     "shell.execute_reply.started": "2024-04-10T20:33:46.948649Z"
+     "iopub.execute_input": "2024-04-22T17:53:02.800514Z",
+     "iopub.status.busy": "2024-04-22T17:53:02.800172Z",
+     "iopub.status.idle": "2024-04-22T17:53:02.806164Z",
+     "shell.execute_reply": "2024-04-22T17:53:02.805877Z",
+     "shell.execute_reply.started": "2024-04-22T17:53:02.800499Z"
     }
    },
    "outputs": [
@@ -429,20 +988,20 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (1, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>coef_enet_non_negative</th><th>coef_ridge</th></tr><tr><td>struct[3]</td><td>struct[3]</td></tr></thead><tbody><tr><td>{0.0,0.0,0.0}</td><td>{-0.91927,-0.911867,-0.920933}</td></tr></tbody></table></div>"
+       "<small>shape: (1, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>coef_enet_non_negative</th><th>coef_ridge</th></tr><tr><td>struct[3]</td><td>struct[3]</td></tr></thead><tbody><tr><td>{0.0,0.0,0.0}</td><td>{-0.912021,-0.898583,-0.908957}</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (1, 2)\n",
-       "┌────────────────────────┬────────────────────────────────┐\n",
-       "│ coef_enet_non_negative ┆ coef_ridge                     │\n",
-       "│ ---                    ┆ ---                            │\n",
-       "│ struct[3]              ┆ struct[3]                      │\n",
-       "╞════════════════════════╪════════════════════════════════╡\n",
-       "│ {0.0,0.0,0.0}          ┆ {-0.91927,-0.911867,-0.920933} │\n",
-       "└────────────────────────┴────────────────────────────────┘"
+       "┌────────────────────────┬─────────────────────────────────┐\n",
+       "│ coef_enet_non_negative ┆ coef_ridge                      │\n",
+       "│ ---                    ┆ ---                             │\n",
+       "│ struct[3]              ┆ struct[3]                       │\n",
+       "╞════════════════════════╪═════════════════════════════════╡\n",
+       "│ {0.0,0.0,0.0}          ┆ {-0.912021,-0.898583,-0.908957} │\n",
+       "└────────────────────────┴─────────────────────────────────┘"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -465,6 +1024,155 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fbb846a5-2dd4-48d4-a21d-ed35d12ea7d9",
+   "metadata": {},
+   "source": [
+    "### Example: Elastic Net w/ large number of predictors\n",
+    "- most of them are sparse / zero"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "e81f59b7-5c81-4cc5-9f5f-06fd0ef8b90b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:53:04.108677Z",
+     "iopub.status.busy": "2024-04-22T17:53:04.108504Z",
+     "iopub.status.idle": "2024-04-22T17:53:04.548357Z",
+     "shell.execute_reply": "2024-04-22T17:53:04.547978Z",
+     "shell.execute_reply.started": "2024-04-22T17:53:04.108663Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.linear_model import ElasticNet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "95136952-e737-4c58-a86c-7c14ce085169",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:58:17.454692Z",
+     "iopub.status.busy": "2024-04-22T17:58:17.454451Z",
+     "iopub.status.idle": "2024-04-22T17:58:17.472629Z",
+     "shell.execute_reply": "2024-04-22T17:58:17.472265Z",
+     "shell.execute_reply.started": "2024-04-22T17:58:17.454679Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df_wide = _make_data(n_samples=1_000, n_features=1_000, sparsity=0.9)\n",
+    "features = [pl.col(f\"x{i+1}\") for i in range(1_000)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "892cc6d9-3e6c-45d7-ae52-f66014d94a5d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:59:24.217475Z",
+     "iopub.status.busy": "2024-04-22T17:59:24.217222Z",
+     "iopub.status.idle": "2024-04-22T17:59:24.324690Z",
+     "shell.execute_reply": "2024-04-22T17:59:24.324081Z",
+     "shell.execute_reply.started": "2024-04-22T17:59:24.217461Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# implementation matches sklearn \n",
+    "coef = df_wide.select(pl.col(\"y\").least_squares.elastic_net(\n",
+    "    *features,\n",
+    "    l1_ratio=0.5,\n",
+    "    alpha=0.1,\n",
+    "    mode=\"coefficients\",\n",
+    "    solve_method=\"cd\",\n",
+    "    max_iter=1_000,\n",
+    "    tol=0.0001,\n",
+    ")).unnest(\"coefficients\")\n",
+    "\n",
+    "mdl = ElasticNet(l1_ratio=0.5, max_iter=1_000,  tol=0.0001, fit_intercept=False, alpha=0.1)\n",
+    "x, y = df_wide.select(*features).to_numpy(), df_wide.select(\"y\").to_numpy()\n",
+    "mdl.fit(x, y)\n",
+    "\n",
+    "assert np.allclose(mdl.coef_, coef.to_numpy(), rtol=1.e-4, atol=1.e-4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "0cbb5c0d-5093-4125-825a-c8f6e7c2083d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:59:24.873713Z",
+     "iopub.status.busy": "2024-04-22T17:59:24.873412Z",
+     "iopub.status.idle": "2024-04-22T17:59:31.285254Z",
+     "shell.execute_reply": "2024-04-22T17:59:31.284434Z",
+     "shell.execute_reply.started": "2024-04-22T17:59:24.873693Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "45.7 ms ± 3.26 ms per loop (mean ± std. dev. of 7 runs, 20 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -n 20\n",
+    "df_wide.with_columns(pl.col(\"y\").least_squares.elastic_net(\n",
+    "    *features,\n",
+    "    l1_ratio=0.5,\n",
+    "    alpha=0.1,\n",
+    "    mode=\"predictions\",\n",
+    "    solve_method=\"cd\",\n",
+    "    max_iter=1_000,\n",
+    "    tol=0.0001,\n",
+    ").alias(\"predictions\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "1adbc415-672d-41cc-ba70-7efc98c952ff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-22T17:59:31.286509Z",
+     "iopub.status.busy": "2024-04-22T17:59:31.286355Z",
+     "iopub.status.idle": "2024-04-22T17:59:34.255025Z",
+     "shell.execute_reply": "2024-04-22T17:59:34.254677Z",
+     "shell.execute_reply.started": "2024-04-22T17:59:31.286495Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21.2 ms ± 4.02 ms per loop (mean ± std. dev. of 7 runs, 20 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -n 20\n",
+    "df_wide.with_columns(pl.col(\"y\").least_squares.elastic_net(\n",
+    "    *features,\n",
+    "    l1_ratio=0.5,\n",
+    "    alpha=0.1,\n",
+    "    mode=\"predictions\",\n",
+    "    solve_method=\"cd_active_set\",  # can get a meaningful speed up by using active set\n",
+    "    max_iter=1_000,\n",
+    "    tol=0.0001,\n",
+    ").alias(\"predictions\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0d51c5a1-bb89-4e45-97bd-7e3bda6beae0",
    "metadata": {},
    "source": [
@@ -477,15 +1185,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 55,
    "id": "8965d16a-1703-4a75-9729-d8fbadb7a1c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-10T20:33:54.487896Z",
-     "iopub.status.busy": "2024-04-10T20:33:54.487521Z",
-     "iopub.status.idle": "2024-04-10T20:33:54.814794Z",
-     "shell.execute_reply": "2024-04-10T20:33:54.814490Z",
-     "shell.execute_reply.started": "2024-04-10T20:33:54.487868Z"
+     "iopub.execute_input": "2024-04-22T17:59:38.308011Z",
+     "iopub.status.busy": "2024-04-22T17:59:38.307828Z",
+     "iopub.status.idle": "2024-04-22T17:59:38.534424Z",
+     "shell.execute_reply": "2024-04-22T17:59:38.533146Z",
+     "shell.execute_reply.started": "2024-04-22T17:59:38.307996Z"
     }
    },
    "outputs": [
@@ -513,7 +1221,7 @@
        "└─────────────┴─────────────┘"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -529,15 +1237,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 56,
    "id": "aa610cd9-3b3f-43ce-b9cc-24a92df55307",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-10T20:33:56.625845Z",
-     "iopub.status.busy": "2024-04-10T20:33:56.625112Z",
-     "iopub.status.idle": "2024-04-10T20:33:56.633119Z",
-     "shell.execute_reply": "2024-04-10T20:33:56.632340Z",
-     "shell.execute_reply.started": "2024-04-10T20:33:56.625806Z"
+     "iopub.execute_input": "2024-04-22T17:59:38.951969Z",
+     "iopub.status.busy": "2024-04-22T17:59:38.951696Z",
+     "iopub.status.idle": "2024-04-22T17:59:38.955717Z",
+     "shell.execute_reply": "2024-04-22T17:59:38.955314Z",
+     "shell.execute_reply.started": "2024-04-22T17:59:38.951953Z"
     }
    },
    "outputs": [],
@@ -571,15 +1279,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 57,
    "id": "33a8ee68-dc8b-4a2e-a590-73a4998bc33e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-10T20:34:00.488695Z",
-     "iopub.status.busy": "2024-04-10T20:34:00.488075Z",
-     "iopub.status.idle": "2024-04-10T20:34:00.512500Z",
-     "shell.execute_reply": "2024-04-10T20:34:00.512026Z",
-     "shell.execute_reply.started": "2024-04-10T20:34:00.488659Z"
+     "iopub.execute_input": "2024-04-22T17:59:39.402297Z",
+     "iopub.status.busy": "2024-04-22T17:59:39.398741Z",
+     "iopub.status.idle": "2024-04-22T17:59:39.456982Z",
+     "shell.execute_reply": "2024-04-22T17:59:39.456425Z",
+     "shell.execute_reply.started": "2024-04-22T17:59:39.402269Z"
     }
    },
    "outputs": [
@@ -593,43 +1301,44 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (2_000, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>rolling_ridge_coef</th><th>recursive_least_squares_coef</th><th>expanding_ols_pred</th></tr><tr><td>struct[3]</td><td>struct[3]</td><td>f32</td></tr></thead><tbody><tr><td>{0.0,0.0,0.0}</td><td>{-0.999436,-0.999317,-1.003672}</td><td>1.01911</td></tr><tr><td>{0.0,0.0,0.0}</td><td>{-0.981326,-1.010655,-0.989518}</td><td>-1.986911</td></tr><tr><td>{0.0,0.0,0.0}</td><td>{-0.999681,-0.999694,-0.997705}</td><td>-2.273605</td></tr><tr><td>{0.0,0.0,0.0}</td><td>{-1.002054,-0.99703,-1.011049}</td><td>0.713363</td></tr><tr><td>{0.0,0.0,0.0}</td><td>{-1.01267,-1.047104,-1.022372}</td><td>-1.524843</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>{-0.99819,-0.998837,-0.99271}</td><td>{-1.004297,-1.004904,-0.990937}</td><td>-0.695928</td></tr><tr><td>{-0.99821,-0.998581,-0.992718}</td><td>{-1.004473,-1.002611,-0.990368}</td><td>3.224019</td></tr><tr><td>{-1.004952,-1.003536,-0.99391}</td><td>{-1.003174,-0.991553,-1.012009}</td><td>-4.029209</td></tr><tr><td>{-0.997664,-1.003617,-1.000195}</td><td>{-1.011577,-1.01432,-0.997295}</td><td>0.60629</td></tr><tr><td>{-0.997986,-1.004691,-0.999824}</td><td>{-1.013571,-1.020214,-0.994661}</td><td>2.030797</td></tr></tbody></table></div>"
+       "<small>shape: (2_000, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>rolling_ridge_coef</th><th>recursive_least_squares_coef</th><th>expanding_ols_pred</th></tr><tr><td>struct[3]</td><td>struct[3]</td><td>f64</td></tr></thead><tbody><tr><td>{null,null,null}</td><td>{-1.031467,-0.966938,-1.160281}</td><td>-0.627675</td></tr><tr><td>{null,null,null}</td><td>{-1.013228,-0.932454,-1.045596}</td><td>-0.127212</td></tr><tr><td>{null,null,null}</td><td>{-1.003344,-1.002429,-0.998195}</td><td>-1.48872</td></tr><tr><td>{null,null,null}</td><td>{-1.053291,-1.026248,-0.99826}</td><td>1.852231</td></tr><tr><td>{null,null,null}</td><td>{-1.059251,-1.017933,-1.014118}</td><td>3.941405</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>{-0.995486,-1.003153,-0.998155}</td><td>{-0.987406,-1.004047,-1.004306}</td><td>-1.674772</td></tr><tr><td>{-0.995348,-1.004411,-0.99898}</td><td>{-0.985392,-1.011036,-1.00789}</td><td>-3.506569</td></tr><tr><td>{-1.001142,-1.002267,-1.002736}</td><td>{-1.001857,-0.980484,-1.007321}</td><td>-0.618197</td></tr><tr><td>{-1.001257,-1.001316,-1.003019}</td><td>{-1.002182,-0.978417,-1.006454}</td><td>-0.692359</td></tr><tr><td>{-1.002536,-0.993688,-0.998938}</td><td>{-0.968934,-1.00696,-1.010813}</td><td>0.159536</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (2_000, 3)\n",
        "┌─────────────────────────────────┬─────────────────────────────────┬────────────────────┐\n",
        "│ rolling_ridge_coef              ┆ recursive_least_squares_coef    ┆ expanding_ols_pred │\n",
        "│ ---                             ┆ ---                             ┆ ---                │\n",
-       "│ struct[3]                       ┆ struct[3]                       ┆ f32                │\n",
+       "│ struct[3]                       ┆ struct[3]                       ┆ f64                │\n",
        "╞═════════════════════════════════╪═════════════════════════════════╪════════════════════╡\n",
-       "│ {0.0,0.0,0.0}                   ┆ {-0.999436,-0.999317,-1.003672} ┆ 1.01911            │\n",
-       "│ {0.0,0.0,0.0}                   ┆ {-0.981326,-1.010655,-0.989518} ┆ -1.986911          │\n",
-       "│ {0.0,0.0,0.0}                   ┆ {-0.999681,-0.999694,-0.997705} ┆ -2.273605          │\n",
-       "│ {0.0,0.0,0.0}                   ┆ {-1.002054,-0.99703,-1.011049}  ┆ 0.713363           │\n",
-       "│ {0.0,0.0,0.0}                   ┆ {-1.01267,-1.047104,-1.022372}  ┆ -1.524843          │\n",
+       "│ {null,null,null}                ┆ {-1.031467,-0.966938,-1.160281} ┆ -0.627675          │\n",
+       "│ {null,null,null}                ┆ {-1.013228,-0.932454,-1.045596} ┆ -0.127212          │\n",
+       "│ {null,null,null}                ┆ {-1.003344,-1.002429,-0.998195} ┆ -1.48872           │\n",
+       "│ {null,null,null}                ┆ {-1.053291,-1.026248,-0.99826}  ┆ 1.852231           │\n",
+       "│ {null,null,null}                ┆ {-1.059251,-1.017933,-1.014118} ┆ 3.941405           │\n",
        "│ …                               ┆ …                               ┆ …                  │\n",
-       "│ {-0.99819,-0.998837,-0.99271}   ┆ {-1.004297,-1.004904,-0.990937} ┆ -0.695928          │\n",
-       "│ {-0.99821,-0.998581,-0.992718}  ┆ {-1.004473,-1.002611,-0.990368} ┆ 3.224019           │\n",
-       "│ {-1.004952,-1.003536,-0.99391}  ┆ {-1.003174,-0.991553,-1.012009} ┆ -4.029209          │\n",
-       "│ {-0.997664,-1.003617,-1.000195} ┆ {-1.011577,-1.01432,-0.997295}  ┆ 0.60629            │\n",
-       "│ {-0.997986,-1.004691,-0.999824} ┆ {-1.013571,-1.020214,-0.994661} ┆ 2.030797           │\n",
+       "│ {-0.995486,-1.003153,-0.998155} ┆ {-0.987406,-1.004047,-1.004306} ┆ -1.674772          │\n",
+       "│ {-0.995348,-1.004411,-0.99898}  ┆ {-0.985392,-1.011036,-1.00789}  ┆ -3.506569          │\n",
+       "│ {-1.001142,-1.002267,-1.002736} ┆ {-1.001857,-0.980484,-1.007321} ┆ -0.618197          │\n",
+       "│ {-1.001257,-1.001316,-1.003019} ┆ {-1.002182,-0.978417,-1.006454} ┆ -0.692359          │\n",
+       "│ {-1.002536,-0.993688,-0.998938} ┆ {-0.968934,-1.00696,-1.010813}  ┆ 0.159536           │\n",
        "└─────────────────────────────────┴─────────────────────────────────┴────────────────────┘"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "df.select(\n",
-    "    pl.col(\"y\").least_squares.from_formula(\"x1 + x2 + x3 -1\", \n",
+    "    pl.col(\"y\").least_squares.rolling_ols(\"x1\", \"x2\", \"x3\", \n",
     "                                           window_size=252, \n",
     "                                           min_periods=5, \n",
     "                                           alpha=0.0001,  \n",
-    "                                           mode=\"coefficients\").over(\"group\").alias(\"rolling_ridge_coef\"),\n",
+    "                                           mode=\"coefficients\"\n",
+    "                                          ).over(\"group\").alias(\"rolling_ridge_coef\"),\n",
     "    pl.col(\"y\").least_squares.rls(\n",
-    "        pl.col(\"x1\"), pl.col(\"x2\"), pl.col(\"x3\"),\n",
+    "        \"x1\", \"x2\", \"x3\",\n",
     "        half_life=21.0, # exponential memory proportional to a half-life of 21 samples\n",
     "        initial_state_mean=[-1.0, -1.0, -1.0],  # prior mean for initial coefficients\n",
     "        initial_state_covariance=10.0,  # inversely proportional to L2 prior towards prior mean\n",
@@ -652,15 +1361,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 58,
    "id": "ff412921-2c2d-46b3-baad-d54067fa3312",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-10T20:34:03.717709Z",
-     "iopub.status.busy": "2024-04-10T20:34:03.717058Z",
-     "iopub.status.idle": "2024-04-10T20:34:03.731915Z",
-     "shell.execute_reply": "2024-04-10T20:34:03.730851Z",
-     "shell.execute_reply.started": "2024-04-10T20:34:03.717669Z"
+     "iopub.execute_input": "2024-04-22T17:59:39.761606Z",
+     "iopub.status.busy": "2024-04-22T17:59:39.761430Z",
+     "iopub.status.idle": "2024-04-22T17:59:39.790918Z",
+     "shell.execute_reply": "2024-04-22T17:59:39.790278Z",
+     "shell.execute_reply.started": "2024-04-22T17:59:39.761592Z"
     }
    },
    "outputs": [
@@ -674,7 +1383,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (5, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>group</th><th>coefficients</th></tr><tr><td>i64</td><td>struct[2]</td></tr></thead><tbody><tr><td>2</td><td>{-1.032807,-1.043651}</td></tr><tr><td>3</td><td>{-0.99592,-0.985827}</td></tr><tr><td>4</td><td>{-1.040148,-0.995546}</td></tr><tr><td>0</td><td>{-0.962558,-1.095777}</td></tr><tr><td>1</td><td>{-0.961928,-1.036407}</td></tr></tbody></table></div>"
+       "<small>shape: (5, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>group</th><th>coefficients</th></tr><tr><td>i64</td><td>struct[2]</td></tr></thead><tbody><tr><td>3</td><td>{-1.074243,-1.050159}</td></tr><tr><td>0</td><td>{-1.028893,-1.004733}</td></tr><tr><td>2</td><td>{-0.948578,-0.917406}</td></tr><tr><td>4</td><td>{-1.037308,-0.981468}</td></tr><tr><td>1</td><td>{-1.094156,-0.946028}</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (5, 2)\n",
@@ -683,15 +1392,15 @@
        "│ ---   ┆ ---                   │\n",
        "│ i64   ┆ struct[2]             │\n",
        "╞═══════╪═══════════════════════╡\n",
-       "│ 2     ┆ {-1.032807,-1.043651} │\n",
-       "│ 3     ┆ {-0.99592,-0.985827}  │\n",
-       "│ 4     ┆ {-1.040148,-0.995546} │\n",
-       "│ 0     ┆ {-0.962558,-1.095777} │\n",
-       "│ 1     ┆ {-0.961928,-1.036407} │\n",
+       "│ 3     ┆ {-1.074243,-1.050159} │\n",
+       "│ 0     ┆ {-1.028893,-1.004733} │\n",
+       "│ 2     ┆ {-0.948578,-0.917406} │\n",
+       "│ 4     ┆ {-1.037308,-0.981468} │\n",
+       "│ 1     ┆ {-1.094156,-0.946028} │\n",
        "└───────┴───────────────────────┘"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -717,18 +1426,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 59,
    "id": "931b667e-cf4d-4b53-be9b-85278c6fd16c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-10T20:34:05.523456Z",
-     "iopub.status.busy": "2024-04-10T20:34:05.522801Z",
-     "iopub.status.idle": "2024-04-10T20:34:05.539512Z",
-     "shell.execute_reply": "2024-04-10T20:34:05.538563Z",
-     "shell.execute_reply.started": "2024-04-10T20:34:05.523419Z"
+     "iopub.execute_input": "2024-04-22T17:59:39.931175Z",
+     "iopub.status.busy": "2024-04-22T17:59:39.929688Z",
+     "iopub.status.idle": "2024-04-22T17:59:39.979453Z",
+     "shell.execute_reply": "2024-04-22T17:59:39.970658Z",
+     "shell.execute_reply.started": "2024-04-22T17:59:39.931155Z"
     }
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "join parallel: true\n",
+      "INNER join dataframes finished\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -739,24 +1456,24 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (5, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>group</th><th>predictions_test</th></tr><tr><td>i64</td><td>f32</td></tr></thead><tbody><tr><td>0</td><td>5.21625</td></tr><tr><td>0</td><td>-0.810267</td></tr><tr><td>0</td><td>0.377538</td></tr><tr><td>0</td><td>-0.982739</td></tr><tr><td>0</td><td>-1.07014</td></tr></tbody></table></div>"
+       "<small>shape: (5, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>group</th><th>predictions_test</th></tr><tr><td>i64</td><td>f64</td></tr></thead><tbody><tr><td>0</td><td>0.003367</td></tr><tr><td>0</td><td>-1.682214</td></tr><tr><td>0</td><td>0.599761</td></tr><tr><td>0</td><td>1.30026</td></tr><tr><td>0</td><td>-1.240682</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (5, 2)\n",
        "┌───────┬──────────────────┐\n",
        "│ group ┆ predictions_test │\n",
        "│ ---   ┆ ---              │\n",
-       "│ i64   ┆ f32              │\n",
+       "│ i64   ┆ f64              │\n",
        "╞═══════╪══════════════════╡\n",
-       "│ 0     ┆ 5.21625          │\n",
-       "│ 0     ┆ -0.810267        │\n",
-       "│ 0     ┆ 0.377538         │\n",
-       "│ 0     ┆ -0.982739        │\n",
-       "│ 0     ┆ -1.07014         │\n",
+       "│ 0     ┆ 0.003367         │\n",
+       "│ 0     ┆ -1.682214        │\n",
+       "│ 0     ┆ 0.599761         │\n",
+       "│ 0     ┆ 1.30026          │\n",
+       "│ 0     ┆ -1.240682        │\n",
        "└───────┴──────────────────┘"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -784,150 +1501,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "d1d58b93-446d-431d-a537-c8e9d20d53c4",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-04-12T16:18:04.167518Z",
-     "iopub.status.busy": "2024-04-12T16:18:04.166964Z",
-     "iopub.status.idle": "2024-04-12T16:18:04.172328Z",
-     "shell.execute_reply": "2024-04-12T16:18:04.171469Z",
-     "shell.execute_reply.started": "2024-04-12T16:18:04.167485Z"
-    }
-   },
+   "execution_count": null,
+   "id": "0859cfce-2084-429d-b9ee-7b54bf5b5f4d",
+   "metadata": {},
    "outputs": [],
-   "source": [
-    "from polars_ols.least_squares import convert_series_to_struct"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "f0d9b6e8-e205-468f-b071-f5f9b276c2ca",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-04-12T16:18:46.975433Z",
-     "iopub.status.busy": "2024-04-12T16:18:46.974941Z",
-     "iopub.status.idle": "2024-04-12T16:18:46.990354Z",
-     "shell.execute_reply": "2024-04-12T16:18:46.989635Z",
-     "shell.execute_reply.started": "2024-04-12T16:18:46.975399Z"
-    },
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "field_name=\"x1\"\n",
-      "field_name=\"x2\"\n",
-      "series_name=\"x1\"\n",
-      "series_name=\"x2\"\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (10, 1)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>x1</th></tr><tr><td>struct[2]</td></tr></thead><tbody><tr><td>{0.72,0.24}</td></tr><tr><td>{-2.43,0.18}</td></tr><tr><td>{-0.63,-0.95}</td></tr><tr><td>{0.05,0.23}</td></tr><tr><td>{-0.07,0.44}</td></tr><tr><td>{0.65,1.01}</td></tr><tr><td>{-0.02,-2.08}</td></tr><tr><td>{-1.64,-1.36}</td></tr><tr><td>{-0.92,0.01}</td></tr><tr><td>{-0.27,0.75}</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (10, 1)\n",
-       "┌───────────────┐\n",
-       "│ x1            │\n",
-       "│ ---           │\n",
-       "│ struct[2]     │\n",
-       "╞═══════════════╡\n",
-       "│ {0.72,0.24}   │\n",
-       "│ {-2.43,0.18}  │\n",
-       "│ {-0.63,-0.95} │\n",
-       "│ {0.05,0.23}   │\n",
-       "│ {-0.07,0.44}  │\n",
-       "│ {0.65,1.01}   │\n",
-       "│ {-0.02,-2.08} │\n",
-       "│ {-1.64,-1.36} │\n",
-       "│ {-0.92,0.01}  │\n",
-       "│ {-0.27,0.75}  │\n",
-       "└───────────────┘"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df = pl.DataFrame({\"y\": [1.16, -2.16, -1.57, 0.21, 0.22, 1.6, -2.11, -2.92, -0.86, 0.47],\n",
-    "                   \"x1\": [0.72, -2.43, -0.63, 0.05, -0.07, 0.65, -0.02, -1.64, -0.92, -0.27],\n",
-    "                   \"x2\": [0.24, 0.18, -0.95, 0.23, 0.44, 1.01, -2.08, -1.36, 0.01, 0.75],\n",
-    "                   \"group\": [1, 1, 1, 1, 1, 2, 2, 2, 2, 2],\n",
-    "                   \"weights\": [0.34, 0.97, 0.39, 0.8, 0.57, 0.41, 0.19, 0.87, 0.06, 0.34],\n",
-    "                   })\n",
-    "df.select(convert_series_to_struct(pl.col(\"x1\"), pl.col(\"x2\")))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "c473f320-dc5a-4119-8cfd-14a133ace4ae",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-04-12T16:22:46.433399Z",
-     "iopub.status.busy": "2024-04-12T16:22:46.432530Z",
-     "iopub.status.idle": "2024-04-12T16:22:46.474534Z",
-     "shell.execute_reply": "2024-04-12T16:22:46.473552Z",
-     "shell.execute_reply.started": "2024-04-12T16:22:46.433354Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "field_name=\"x1\"\n",
-      "field_name=\"x2\"\n",
-      "field_name=\"x1\"\n",
-      "field_name=\"x2\"\n",
-      "series_name=\"\"\n",
-      "series_name=\"\"\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "panicked at src/expressions.rs:562:46:\n",
-      "called `Result::unwrap()` on an `Err` value: Duplicate(ErrString(\"column with name '' has more than one occurrences\"))\n"
-     ]
-    },
-    {
-     "ename": "ComputeError",
-     "evalue": "the plugin panicked\n\nThe message is suppressed. Set POLARS_VERBOSE=1 to send the panic message to stderr.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mComputeError\u001b[0m                              Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[15], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mdf\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mselect\u001b[49m\u001b[43m(\u001b[49m\u001b[43mconvert_series_to_struct\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpl\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcol\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mx1\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpl\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcol\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mx2\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mover\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mgroup\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/projects/polars_ols/venv/lib/python3.10/site-packages/polars/dataframe/frame.py:8124\u001b[0m, in \u001b[0;36mDataFrame.select\u001b[0;34m(self, *exprs, **named_exprs)\u001b[0m\n\u001b[1;32m   8024\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mselect\u001b[39m(\n\u001b[1;32m   8025\u001b[0m     \u001b[38;5;28mself\u001b[39m, \u001b[38;5;241m*\u001b[39mexprs: IntoExpr \u001b[38;5;241m|\u001b[39m Iterable[IntoExpr], \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mnamed_exprs: IntoExpr\n\u001b[1;32m   8026\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m DataFrame:\n\u001b[1;32m   8027\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   8028\u001b[0m \u001b[38;5;124;03m    Select columns from this DataFrame.\u001b[39;00m\n\u001b[1;32m   8029\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   8122\u001b[0m \u001b[38;5;124;03m    └───────────┘\u001b[39;00m\n\u001b[1;32m   8123\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 8124\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlazy\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mselect\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mexprs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mnamed_exprs\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcollect\u001b[49m\u001b[43m(\u001b[49m\u001b[43m_eager\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/projects/polars_ols/venv/lib/python3.10/site-packages/polars/lazyframe/frame.py:1943\u001b[0m, in \u001b[0;36mLazyFrame.collect\u001b[0;34m(self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, no_optimization, streaming, background, _eager)\u001b[0m\n\u001b[1;32m   1940\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m background:\n\u001b[1;32m   1941\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m InProcessQuery(ldf\u001b[38;5;241m.\u001b[39mcollect_concurrently())\n\u001b[0;32m-> 1943\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m wrap_df(\u001b[43mldf\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcollect\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m)\n",
-      "\u001b[0;31mComputeError\u001b[0m: the plugin panicked\n\nThe message is suppressed. Set POLARS_VERBOSE=1 to send the panic message to stderr."
-     ]
-    }
-   ],
-   "source": [
-    "df.select(convert_series_to_struct(pl.col(\"x1\"), pl.col(\"x2\")).over(\"group\"))"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce7f611f-5fe5-4389-ae03-482d0cd1e5e0",
+   "id": "8e681f36-f53c-4085-8f61-802f00922e34",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3f80629-bf32-4c41-a75c-4490f245ebce",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -949,7 +1540,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -179,23 +179,24 @@ if __name__ == "__main__":
 
     runner.bench_func("benchmark_least_squares_qr", benchmark_least_squares, df, "qr")
     runner.bench_func("benchmark_least_squares_svd", benchmark_least_squares, df, "svd")
-    # runner.bench_func("benchmark_ridge_cholesky", benchmark_ridge, df, "chol")
-    # runner.bench_func("benchmark_ridge_svd", benchmark_ridge, df, "svd")
-    # runner.bench_func("benchmark_wls_from_formula", benchmark_wls_from_formula, df)
-    # runner.bench_func("benchmark_elastic_net", benchmark_elastic_net, df, "cd")
-    # runner.bench_func("benchmark_elastic_net_active_set", benchmark_elastic_net, df,
-    #                   "cd_active_set")
+    runner.bench_func("benchmark_ridge_cholesky", benchmark_ridge, df, "chol")
+    runner.bench_func("benchmark_ridge_svd", benchmark_ridge, df, "svd")
+    runner.bench_func("benchmark_wls_from_formula", benchmark_wls_from_formula, df)
+    runner.bench_func("benchmark_elastic_net", benchmark_elastic_net, df, "cd")
+    runner.bench_func(
+        "benchmark_elastic_net_active_set", benchmark_elastic_net, df, "cd_active_set"
+    )
     # runner.bench_func("benchmark_recursive_least_squares", benchmark_recursive_least_squares, df)
     # runner.bench_func("benchmark_rolling_least_squares", benchmark_rolling_least_squares, df)
 
     runner.bench_func("benchmark_least_squares_numpy_qr", benchmark_least_squares_numpy_qr, df)
     runner.bench_func("benchmark_least_squares_numpy_svd", benchmark_least_squares_numpy_svd, df)
-    # runner.bench_func("benchmark_ridge_sklearn_cholesky", benchmark_ridge_sklearn, df, "cholesky")
-    # runner.bench_func("benchmark_ridge_sklearn_svd", benchmark_ridge_sklearn, df, "svd")
-    # runner.bench_func(
-    #     "benchmark_wls_from_formula_statsmodels", benchmark_wls_from_formula_statsmodels, df
-    # )
-    # runner.bench_func("benchmark_elastic_net_sklearn", benchmark_elastic_net_sklearn, df)
+    runner.bench_func("benchmark_ridge_sklearn_cholesky", benchmark_ridge_sklearn, df, "cholesky")
+    runner.bench_func("benchmark_ridge_sklearn_svd", benchmark_ridge_sklearn, df, "svd")
+    runner.bench_func(
+        "benchmark_wls_from_formula_statsmodels", benchmark_wls_from_formula_statsmodels, df
+    )
+    runner.bench_func("benchmark_elastic_net_sklearn", benchmark_elastic_net_sklearn, df)
     # runner.bench_func(
     #     "benchmark_recursive_least_squares_statsmodels",
     #     benchmark_recursive_least_squares_statsmodels,


### PR DESCRIPTION
This PR provides minor fixes and cosmetic clean-ups: 
1. improves the type annotations of python API functions to ExprOrStr indicating that user can pass shorthand column names if they wish (i.e. `pl.col("y").least_squares.ols("x1", "x2")` is a supported equivalent of `pl.col("y").least_squares.ols(pl.col("x1"), pl.col("x2"))`)
2. fixes demo notebook @AdrienDart  https://github.com/azmyrajab/polars_ols/issues/16. The demo notebook should now be more comprehensive and explains "SolveMethod" and "NullPolicy" usage
3. forces a "rechunk" on rust series prior to conversion to ndarray because that step ensures contiguous memory and zero-copy to ndarray
4. bumps version to v0.3.1