### PR TITLE
add multi-target regression support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,15 +73,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "argminmax"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,7 +1236,7 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
 dependencies = [
- "approx 0.4.0",
+ "approx",
  "cblas-sys",
  "libc",
  "matrixmultiply",
@@ -1925,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "polars_ols"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "blas-src",
  "faer",
  "faer-ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,21 @@ edition = "2021"
 
 [lib]
 name = "polars_ols"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies.pyo3]
+version = "*"
+
+[dependencies.pyo3-polars]
+version = "*"
+
+[features]
+extension-module = ["pyo3/extension-module", "pyo3/abi3-py38", "pyo3/gil-refs", "pyo3-polars/derive"]
+default = ["extension-module"]
 
 [dependencies]
-pyo3 = { version = "*", features = ["extension-module", "abi3-py38", "gil-refs"] }  # set > py38 supported version
-pyo3-polars = { version = "*", features = ["derive"] }
+# pyo3 = { version = "*", features = ["extension-module", "abi3-py38", "gil-refs"] }  # set > py38 supported version
+#pyo3-polars = { version = "*", features = ["derive"] }
 serde = { version = "*", features = ["derive"] }
 polars = { version = "*", features = ["performant", "lazy", "ndarray", "dtype-struct", "nightly"] }
 ndarray-rand = { version = "*" }

--- a/notebooks/polars_ols_demo.ipynb
+++ b/notebooks/polars_ols_demo.ipynb
@@ -6,11 +6,11 @@
    "id": "8d7bae54-e858-410c-a574-da1aa325d90a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:52.460965Z",
-     "iopub.status.busy": "2024-04-22T17:52:52.460792Z",
-     "iopub.status.idle": "2024-04-22T17:52:52.551749Z",
-     "shell.execute_reply": "2024-04-22T17:52:52.551071Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:52.460951Z"
+     "iopub.execute_input": "2024-04-25T17:42:58.884510Z",
+     "iopub.status.busy": "2024-04-25T17:42:58.884072Z",
+     "iopub.status.idle": "2024-04-25T17:42:58.997067Z",
+     "shell.execute_reply": "2024-04-25T17:42:58.996495Z",
+     "shell.execute_reply.started": "2024-04-25T17:42:58.884482Z"
     }
    },
    "outputs": [],
@@ -27,11 +27,11 @@
    "id": "35076da5-137a-4d90-a671-ed1e9d650930",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:52.707925Z",
-     "iopub.status.busy": "2024-04-22T17:52:52.707584Z",
-     "iopub.status.idle": "2024-04-22T17:52:52.716339Z",
-     "shell.execute_reply": "2024-04-22T17:52:52.715460Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:52.707901Z"
+     "iopub.execute_input": "2024-04-25T17:42:59.178866Z",
+     "iopub.status.busy": "2024-04-25T17:42:59.177794Z",
+     "iopub.status.idle": "2024-04-25T17:42:59.193372Z",
+     "shell.execute_reply": "2024-04-25T17:42:59.188864Z",
+     "shell.execute_reply.started": "2024-04-25T17:42:59.178827Z"
     }
    },
    "outputs": [],
@@ -70,11 +70,11 @@
    "id": "5ad1869e-d884-48e2-8f37-f790057ada1a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:53.086757Z",
-     "iopub.status.busy": "2024-04-22T17:52:53.086450Z",
-     "iopub.status.idle": "2024-04-22T17:52:53.090536Z",
-     "shell.execute_reply": "2024-04-22T17:52:53.090160Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:53.086745Z"
+     "iopub.execute_input": "2024-04-25T17:42:59.881263Z",
+     "iopub.status.busy": "2024-04-25T17:42:59.880780Z",
+     "iopub.status.idle": "2024-04-25T17:42:59.888232Z",
+     "shell.execute_reply": "2024-04-25T17:42:59.887741Z",
+     "shell.execute_reply.started": "2024-04-25T17:42:59.881235Z"
     }
    },
    "outputs": [],
@@ -102,11 +102,11 @@
    "id": "f7604a81-cf0b-41ab-b39b-4cd6282797af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:53.470288Z",
-     "iopub.status.busy": "2024-04-22T17:52:53.470000Z",
-     "iopub.status.idle": "2024-04-22T17:52:53.495235Z",
-     "shell.execute_reply": "2024-04-22T17:52:53.494788Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:53.470273Z"
+     "iopub.execute_input": "2024-04-25T17:43:00.574656Z",
+     "iopub.status.busy": "2024-04-25T17:43:00.574219Z",
+     "iopub.status.idle": "2024-04-25T17:43:00.621773Z",
+     "shell.execute_reply": "2024-04-25T17:43:00.621217Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:00.574627Z"
     },
     "scrolled": true
    },
@@ -163,11 +163,11 @@
    "id": "c7748165-bc22-4c0d-98d0-a7813d211449",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:53.638774Z",
-     "iopub.status.busy": "2024-04-22T17:52:53.638593Z",
-     "iopub.status.idle": "2024-04-22T17:52:53.643090Z",
-     "shell.execute_reply": "2024-04-22T17:52:53.642763Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:53.638761Z"
+     "iopub.execute_input": "2024-04-25T17:43:00.947207Z",
+     "iopub.status.busy": "2024-04-25T17:43:00.946753Z",
+     "iopub.status.idle": "2024-04-25T17:43:00.956159Z",
+     "shell.execute_reply": "2024-04-25T17:43:00.955383Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:00.947179Z"
     }
    },
    "outputs": [],
@@ -203,11 +203,11 @@
    "id": "c824074b-cecd-43ef-a8b9-bfaeb44f77ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:54.087503Z",
-     "iopub.status.busy": "2024-04-22T17:52:54.087329Z",
-     "iopub.status.idle": "2024-04-22T17:52:54.100681Z",
-     "shell.execute_reply": "2024-04-22T17:52:54.100236Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:54.087488Z"
+     "iopub.execute_input": "2024-04-25T17:43:01.498312Z",
+     "iopub.status.busy": "2024-04-25T17:43:01.498014Z",
+     "iopub.status.idle": "2024-04-25T17:43:01.517574Z",
+     "shell.execute_reply": "2024-04-25T17:43:01.517156Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:01.498293Z"
     }
    },
    "outputs": [
@@ -273,11 +273,11 @@
    "id": "8b14b8ac-c34c-449c-a109-5198ee01e06e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:54.626201Z",
-     "iopub.status.busy": "2024-04-22T17:52:54.625912Z",
-     "iopub.status.idle": "2024-04-22T17:52:54.652919Z",
-     "shell.execute_reply": "2024-04-22T17:52:54.652647Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:54.626177Z"
+     "iopub.execute_input": "2024-04-25T17:43:02.041125Z",
+     "iopub.status.busy": "2024-04-25T17:43:02.040386Z",
+     "iopub.status.idle": "2024-04-25T17:43:02.053982Z",
+     "shell.execute_reply": "2024-04-25T17:43:02.053292Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:02.041075Z"
     }
    },
    "outputs": [
@@ -330,11 +330,11 @@
    "id": "4271adf2-6cb4-46ee-90c7-4e1ac1d28d93",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:55.093128Z",
-     "iopub.status.busy": "2024-04-22T17:52:55.092923Z",
-     "iopub.status.idle": "2024-04-22T17:52:55.099203Z",
-     "shell.execute_reply": "2024-04-22T17:52:55.098880Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:55.093108Z"
+     "iopub.execute_input": "2024-04-25T17:43:02.609745Z",
+     "iopub.status.busy": "2024-04-25T17:43:02.609300Z",
+     "iopub.status.idle": "2024-04-25T17:43:02.622906Z",
+     "shell.execute_reply": "2024-04-25T17:43:02.622154Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:02.609719Z"
     }
    },
    "outputs": [
@@ -402,11 +402,11 @@
    "id": "e67f6d5f-89fe-44cb-8b8e-4d67cc8323e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:55.946208Z",
-     "iopub.status.busy": "2024-04-22T17:52:55.945919Z",
-     "iopub.status.idle": "2024-04-22T17:52:56.000325Z",
-     "shell.execute_reply": "2024-04-22T17:52:55.997692Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:55.946174Z"
+     "iopub.execute_input": "2024-04-25T17:43:03.962050Z",
+     "iopub.status.busy": "2024-04-25T17:43:03.961579Z",
+     "iopub.status.idle": "2024-04-25T17:43:03.986651Z",
+     "shell.execute_reply": "2024-04-25T17:43:03.986223Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:03.962021Z"
     }
    },
    "outputs": [],
@@ -420,11 +420,11 @@
    "id": "92e17a52-16b5-4f0f-ae87-dbf2d0a402c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:56.138821Z",
-     "iopub.status.busy": "2024-04-22T17:52:56.138659Z",
-     "iopub.status.idle": "2024-04-22T17:52:56.142457Z",
-     "shell.execute_reply": "2024-04-22T17:52:56.141989Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:56.138808Z"
+     "iopub.execute_input": "2024-04-25T17:43:04.174480Z",
+     "iopub.status.busy": "2024-04-25T17:43:04.173771Z",
+     "iopub.status.idle": "2024-04-25T17:43:04.184481Z",
+     "shell.execute_reply": "2024-04-25T17:43:04.183813Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:04.174431Z"
     }
    },
    "outputs": [
@@ -438,7 +438,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (2_000, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>x1</th><th>x2</th><th>x3</th><th>x4</th><th>x5</th><th>y</th><th>group</th><th>sample_weights</th></tr><tr><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>0.12573</td><td>-0.132105</td><td>0.640423</td><td>0.1049</td><td>-0.535669</td><td>-0.154338</td><td>2.0</td><td>0.313882</td></tr><tr><td>0.361595</td><td>1.304</td><td>0.947081</td><td>-0.703735</td><td>null</td><td>-0.777174</td><td>1.0</td><td>0.215647</td></tr><tr><td>null</td><td>0.041326</td><td>-2.325031</td><td>null</td><td>-1.245911</td><td>4.260299</td><td>0.0</td><td>0.975329</td></tr><tr><td>null</td><td>-0.544259</td><td>-0.3163</td><td>0.411631</td><td>1.042513</td><td>0.093387</td><td>1.0</td><td>0.349839</td></tr><tr><td>-0.128535</td><td>1.366463</td><td>-0.665195</td><td>0.35151</td><td>null</td><td>-1.659732</td><td>1.0</td><td>0.180044</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>null</td><td>0.433351</td><td>null</td><td>0.659305</td><td>0.346436</td><td>null</td><td>2.0</td><td>0.921171</td></tr><tr><td>0.73432</td><td>-0.562784</td><td>0.642383</td><td>-0.328101</td><td>-0.704787</td><td>0.239824</td><td>1.0</td><td>0.930792</td></tr><tr><td>-0.880797</td><td>-0.497476</td><td>-0.464837</td><td>1.577698</td><td>0.045559</td><td>0.249027</td><td>1.0</td><td>0.120942</td></tr><tr><td>null</td><td>0.479883</td><td>null</td><td>-0.459391</td><td>null</td><td>-0.395502</td><td>2.0</td><td>0.86176</td></tr><tr><td>1.338043</td><td>null</td><td>-0.416367</td><td>-1.266301</td><td>1.031231</td><td>-0.20221</td><td>1.0</td><td>null</td></tr></tbody></table></div>"
+       "<small>shape: (2_000, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>x1</th><th>x2</th><th>x3</th><th>x4</th><th>x5</th><th>y</th><th>group</th><th>sample_weights</th></tr><tr><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>0.12573</td><td>-0.132105</td><td>0.640423</td><td>0.1049</td><td>-0.535669</td><td>-0.154338</td><td>2.0</td><td>0.313882</td></tr><tr><td>0.361595</td><td>1.304</td><td>0.947081</td><td>-0.703735</td><td>null</td><td>-0.777174</td><td>1.0</td><td>0.215647</td></tr><tr><td>null</td><td>null</td><td>-2.325031</td><td>-0.218792</td><td>-1.245911</td><td>4.260299</td><td>0.0</td><td>0.975329</td></tr><tr><td>null</td><td>-0.544259</td><td>-0.3163</td><td>0.411631</td><td>1.042513</td><td>0.093387</td><td>1.0</td><td>0.349839</td></tr><tr><td>-0.128535</td><td>1.366463</td><td>-0.665195</td><td>0.35151</td><td>null</td><td>-1.659732</td><td>1.0</td><td>0.180044</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>null</td><td>0.433351</td><td>-1.199857</td><td>null</td><td>0.346436</td><td>null</td><td>2.0</td><td>0.921171</td></tr><tr><td>0.73432</td><td>-0.562784</td><td>0.642383</td><td>-0.328101</td><td>-0.704787</td><td>0.239824</td><td>1.0</td><td>0.930792</td></tr><tr><td>-0.880797</td><td>-0.497476</td><td>-0.464837</td><td>1.577698</td><td>0.045559</td><td>0.249027</td><td>1.0</td><td>0.120942</td></tr><tr><td>null</td><td>0.479883</td><td>0.611798</td><td>null</td><td>null</td><td>-0.395502</td><td>2.0</td><td>0.86176</td></tr><tr><td>1.338043</td><td>-0.443767</td><td>null</td><td>-1.266301</td><td>1.031231</td><td>-0.20221</td><td>1.0</td><td>null</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (2_000, 8)\n",
@@ -449,15 +449,15 @@
        "╞═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════╪════════════════╡\n",
        "│ 0.12573   ┆ -0.132105 ┆ 0.640423  ┆ 0.1049    ┆ -0.535669 ┆ -0.154338 ┆ 2.0   ┆ 0.313882       │\n",
        "│ 0.361595  ┆ 1.304     ┆ 0.947081  ┆ -0.703735 ┆ null      ┆ -0.777174 ┆ 1.0   ┆ 0.215647       │\n",
-       "│ null      ┆ 0.041326  ┆ -2.325031 ┆ null      ┆ -1.245911 ┆ 4.260299  ┆ 0.0   ┆ 0.975329       │\n",
+       "│ null      ┆ null      ┆ -2.325031 ┆ -0.218792 ┆ -1.245911 ┆ 4.260299  ┆ 0.0   ┆ 0.975329       │\n",
        "│ null      ┆ -0.544259 ┆ -0.3163   ┆ 0.411631  ┆ 1.042513  ┆ 0.093387  ┆ 1.0   ┆ 0.349839       │\n",
        "│ -0.128535 ┆ 1.366463  ┆ -0.665195 ┆ 0.35151   ┆ null      ┆ -1.659732 ┆ 1.0   ┆ 0.180044       │\n",
        "│ …         ┆ …         ┆ …         ┆ …         ┆ …         ┆ …         ┆ …     ┆ …              │\n",
-       "│ null      ┆ 0.433351  ┆ null      ┆ 0.659305  ┆ 0.346436  ┆ null      ┆ 2.0   ┆ 0.921171       │\n",
+       "│ null      ┆ 0.433351  ┆ -1.199857 ┆ null      ┆ 0.346436  ┆ null      ┆ 2.0   ┆ 0.921171       │\n",
        "│ 0.73432   ┆ -0.562784 ┆ 0.642383  ┆ -0.328101 ┆ -0.704787 ┆ 0.239824  ┆ 1.0   ┆ 0.930792       │\n",
        "│ -0.880797 ┆ -0.497476 ┆ -0.464837 ┆ 1.577698  ┆ 0.045559  ┆ 0.249027  ┆ 1.0   ┆ 0.120942       │\n",
-       "│ null      ┆ 0.479883  ┆ null      ┆ -0.459391 ┆ null      ┆ -0.395502 ┆ 2.0   ┆ 0.86176        │\n",
-       "│ 1.338043  ┆ null      ┆ -0.416367 ┆ -1.266301 ┆ 1.031231  ┆ -0.20221  ┆ 1.0   ┆ null           │\n",
+       "│ null      ┆ 0.479883  ┆ 0.611798  ┆ null      ┆ null      ┆ -0.395502 ┆ 2.0   ┆ 0.86176        │\n",
+       "│ 1.338043  ┆ -0.443767 ┆ null      ┆ -1.266301 ┆ 1.031231  ┆ -0.20221  ┆ 1.0   ┆ null           │\n",
        "└───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────┴────────────────┘"
       ]
      },
@@ -476,11 +476,11 @@
    "id": "527c85d6-0054-44ac-a099-dcb7068b2f3f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:56.330351Z",
-     "iopub.status.busy": "2024-04-22T17:52:56.330133Z",
-     "iopub.status.idle": "2024-04-22T17:52:56.333519Z",
-     "shell.execute_reply": "2024-04-22T17:52:56.332947Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:56.330335Z"
+     "iopub.execute_input": "2024-04-25T17:43:04.533718Z",
+     "iopub.status.busy": "2024-04-25T17:43:04.533291Z",
+     "iopub.status.idle": "2024-04-25T17:43:04.538348Z",
+     "shell.execute_reply": "2024-04-25T17:43:04.537800Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:04.533693Z"
     }
    },
    "outputs": [
@@ -513,11 +513,11 @@
    "id": "a4d04c0b-f464-456f-b292-c0576718ddf9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:56.820409Z",
-     "iopub.status.busy": "2024-04-22T17:52:56.820230Z",
-     "iopub.status.idle": "2024-04-22T17:52:56.826103Z",
-     "shell.execute_reply": "2024-04-22T17:52:56.825776Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:56.820393Z"
+     "iopub.execute_input": "2024-04-25T17:43:05.013674Z",
+     "iopub.status.busy": "2024-04-25T17:43:05.013240Z",
+     "iopub.status.idle": "2024-04-25T17:43:05.025901Z",
+     "shell.execute_reply": "2024-04-25T17:43:05.025161Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:05.013648Z"
     }
    },
    "outputs": [
@@ -526,17 +526,17 @@
      "output_type": "stream",
      "text": [
       "shape: (5, 1)\n",
-      "┌───────────┐\n",
-      "│ y         │\n",
-      "│ ---       │\n",
-      "│ f64       │\n",
-      "╞═══════════╡\n",
-      "│ null      │\n",
-      "│ 0.081255  │\n",
-      "│ 0.026447  │\n",
-      "│ -0.377051 │\n",
-      "│ 0.409127  │\n",
-      "└───────────┘\n"
+      "┌──────────┐\n",
+      "│ y        │\n",
+      "│ ---      │\n",
+      "│ f64      │\n",
+      "╞══════════╡\n",
+      "│ null     │\n",
+      "│ 0.082407 │\n",
+      "│ 0.06314  │\n",
+      "│ 0.571505 │\n",
+      "│ 0.419788 │\n",
+      "└──────────┘\n"
      ]
     }
    ],
@@ -583,11 +583,11 @@
    "id": "9a605974-3218-4dea-929d-71752577d018",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:57.353780Z",
-     "iopub.status.busy": "2024-04-22T17:52:57.353532Z",
-     "iopub.status.idle": "2024-04-22T17:52:57.361291Z",
-     "shell.execute_reply": "2024-04-22T17:52:57.360911Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:57.353759Z"
+     "iopub.execute_input": "2024-04-25T17:43:05.639743Z",
+     "iopub.status.busy": "2024-04-25T17:43:05.639233Z",
+     "iopub.status.idle": "2024-04-25T17:43:05.651328Z",
+     "shell.execute_reply": "2024-04-25T17:43:05.650462Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:05.639712Z"
     }
    },
    "outputs": [
@@ -637,11 +637,11 @@
    "id": "9966577c-e91f-4fdd-88c6-bd26ee2b63b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:57.957569Z",
-     "iopub.status.busy": "2024-04-22T17:52:57.957371Z",
-     "iopub.status.idle": "2024-04-22T17:52:57.963563Z",
-     "shell.execute_reply": "2024-04-22T17:52:57.963259Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:57.957554Z"
+     "iopub.execute_input": "2024-04-25T17:43:06.388226Z",
+     "iopub.status.busy": "2024-04-25T17:43:06.387787Z",
+     "iopub.status.idle": "2024-04-25T17:43:06.399037Z",
+     "shell.execute_reply": "2024-04-25T17:43:06.398286Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:06.388201Z"
     }
    },
    "outputs": [
@@ -674,11 +674,11 @@
    "id": "e1454e57-7a21-4da2-a525-233eda2c2d8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:58.278029Z",
-     "iopub.status.busy": "2024-04-22T17:52:58.277781Z",
-     "iopub.status.idle": "2024-04-22T17:52:58.281106Z",
-     "shell.execute_reply": "2024-04-22T17:52:58.280662Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:58.278008Z"
+     "iopub.execute_input": "2024-04-25T17:43:06.905749Z",
+     "iopub.status.busy": "2024-04-25T17:43:06.905410Z",
+     "iopub.status.idle": "2024-04-25T17:43:06.909660Z",
+     "shell.execute_reply": "2024-04-25T17:43:06.909155Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:06.905727Z"
     }
    },
    "outputs": [
@@ -725,11 +725,11 @@
    "id": "2ab3d26e-aaea-4869-9a4d-393288409f7d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:59.297817Z",
-     "iopub.status.busy": "2024-04-22T17:52:59.297321Z",
-     "iopub.status.idle": "2024-04-22T17:52:59.304207Z",
-     "shell.execute_reply": "2024-04-22T17:52:59.303417Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:59.297797Z"
+     "iopub.execute_input": "2024-04-25T17:43:08.187603Z",
+     "iopub.status.busy": "2024-04-25T17:43:08.187153Z",
+     "iopub.status.idle": "2024-04-25T17:43:08.192389Z",
+     "shell.execute_reply": "2024-04-25T17:43:08.191846Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:08.187577Z"
     }
    },
    "outputs": [],
@@ -756,11 +756,11 @@
    "id": "ef238917-1c96-4ed0-ad6e-eca4f1bf7b34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:52:59.916023Z",
-     "iopub.status.busy": "2024-04-22T17:52:59.915843Z",
-     "iopub.status.idle": "2024-04-22T17:52:59.920547Z",
-     "shell.execute_reply": "2024-04-22T17:52:59.920218Z",
-     "shell.execute_reply.started": "2024-04-22T17:52:59.916011Z"
+     "iopub.execute_input": "2024-04-25T17:43:08.946456Z",
+     "iopub.status.busy": "2024-04-25T17:43:08.946042Z",
+     "iopub.status.idle": "2024-04-25T17:43:08.954321Z",
+     "shell.execute_reply": "2024-04-25T17:43:08.953706Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:08.946432Z"
     }
    },
    "outputs": [
@@ -800,11 +800,11 @@
    "id": "76ae5386-d457-48e1-847a-ff31b881bf61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:53:00.579546Z",
-     "iopub.status.busy": "2024-04-22T17:53:00.579234Z",
-     "iopub.status.idle": "2024-04-22T17:53:00.585891Z",
-     "shell.execute_reply": "2024-04-22T17:53:00.585584Z",
-     "shell.execute_reply.started": "2024-04-22T17:53:00.579529Z"
+     "iopub.execute_input": "2024-04-25T17:43:09.620185Z",
+     "iopub.status.busy": "2024-04-25T17:43:09.619734Z",
+     "iopub.status.idle": "2024-04-25T17:43:09.630995Z",
+     "shell.execute_reply": "2024-04-25T17:43:09.630532Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:09.620159Z"
     }
    },
    "outputs": [
@@ -861,11 +861,11 @@
    "id": "943b6e4d-09b0-410a-b571-85497907eb57",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:53:01.174401Z",
-     "iopub.status.busy": "2024-04-22T17:53:01.174152Z",
-     "iopub.status.idle": "2024-04-22T17:53:01.179057Z",
-     "shell.execute_reply": "2024-04-22T17:53:01.178706Z",
-     "shell.execute_reply.started": "2024-04-22T17:53:01.174387Z"
+     "iopub.execute_input": "2024-04-25T17:43:10.252089Z",
+     "iopub.status.busy": "2024-04-25T17:43:10.251654Z",
+     "iopub.status.idle": "2024-04-25T17:43:10.262793Z",
+     "shell.execute_reply": "2024-04-25T17:43:10.261609Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:10.252062Z"
     }
    },
    "outputs": [
@@ -923,11 +923,11 @@
    "id": "bcb50dae-4325-46c6-a939-4bc3ec48633a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:53:02.035744Z",
-     "iopub.status.busy": "2024-04-22T17:53:02.035577Z",
-     "iopub.status.idle": "2024-04-22T17:53:02.039188Z",
-     "shell.execute_reply": "2024-04-22T17:53:02.038816Z",
-     "shell.execute_reply.started": "2024-04-22T17:53:02.035731Z"
+     "iopub.execute_input": "2024-04-25T17:43:11.307722Z",
+     "iopub.status.busy": "2024-04-25T17:43:11.307119Z",
+     "iopub.status.idle": "2024-04-25T17:43:11.314434Z",
+     "shell.execute_reply": "2024-04-25T17:43:11.313739Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:11.307692Z"
     }
    },
    "outputs": [
@@ -970,11 +970,11 @@
    "id": "e35fbf57-3edb-4450-bcf7-a6c2aeef1e6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:53:02.800514Z",
-     "iopub.status.busy": "2024-04-22T17:53:02.800172Z",
-     "iopub.status.idle": "2024-04-22T17:53:02.806164Z",
-     "shell.execute_reply": "2024-04-22T17:53:02.805877Z",
-     "shell.execute_reply.started": "2024-04-22T17:53:02.800499Z"
+     "iopub.execute_input": "2024-04-25T17:43:12.870745Z",
+     "iopub.status.busy": "2024-04-25T17:43:12.870321Z",
+     "iopub.status.idle": "2024-04-25T17:43:12.883332Z",
+     "shell.execute_reply": "2024-04-25T17:43:12.882600Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:12.870720Z"
     }
    },
    "outputs": [
@@ -1037,11 +1037,11 @@
    "id": "e81f59b7-5c81-4cc5-9f5f-06fd0ef8b90b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:53:04.108677Z",
-     "iopub.status.busy": "2024-04-22T17:53:04.108504Z",
-     "iopub.status.idle": "2024-04-22T17:53:04.548357Z",
-     "shell.execute_reply": "2024-04-22T17:53:04.547978Z",
-     "shell.execute_reply.started": "2024-04-22T17:53:04.108663Z"
+     "iopub.execute_input": "2024-04-25T17:43:13.398423Z",
+     "iopub.status.busy": "2024-04-25T17:43:13.397966Z",
+     "iopub.status.idle": "2024-04-25T17:43:13.747421Z",
+     "shell.execute_reply": "2024-04-25T17:43:13.747110Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:13.398393Z"
     }
    },
    "outputs": [],
@@ -1051,15 +1051,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 23,
    "id": "95136952-e737-4c58-a86c-7c14ce085169",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:58:17.454692Z",
-     "iopub.status.busy": "2024-04-22T17:58:17.454451Z",
-     "iopub.status.idle": "2024-04-22T17:58:17.472629Z",
-     "shell.execute_reply": "2024-04-22T17:58:17.472265Z",
-     "shell.execute_reply.started": "2024-04-22T17:58:17.454679Z"
+     "iopub.execute_input": "2024-04-25T17:43:13.748154Z",
+     "iopub.status.busy": "2024-04-25T17:43:13.748058Z",
+     "iopub.status.idle": "2024-04-25T17:43:13.760530Z",
+     "shell.execute_reply": "2024-04-25T17:43:13.760250Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:13.748147Z"
     }
    },
    "outputs": [],
@@ -1070,15 +1070,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 24,
    "id": "892cc6d9-3e6c-45d7-ae52-f66014d94a5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:59:24.217475Z",
-     "iopub.status.busy": "2024-04-22T17:59:24.217222Z",
-     "iopub.status.idle": "2024-04-22T17:59:24.324690Z",
-     "shell.execute_reply": "2024-04-22T17:59:24.324081Z",
-     "shell.execute_reply.started": "2024-04-22T17:59:24.217461Z"
+     "iopub.execute_input": "2024-04-25T17:43:13.828227Z",
+     "iopub.status.busy": "2024-04-25T17:43:13.828075Z",
+     "iopub.status.idle": "2024-04-25T17:43:13.901990Z",
+     "shell.execute_reply": "2024-04-25T17:43:13.901482Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:13.828215Z"
     }
    },
    "outputs": [],
@@ -1103,15 +1103,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 25,
    "id": "0cbb5c0d-5093-4125-825a-c8f6e7c2083d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:59:24.873713Z",
-     "iopub.status.busy": "2024-04-22T17:59:24.873412Z",
-     "iopub.status.idle": "2024-04-22T17:59:31.285254Z",
-     "shell.execute_reply": "2024-04-22T17:59:31.284434Z",
-     "shell.execute_reply.started": "2024-04-22T17:59:24.873693Z"
+     "iopub.execute_input": "2024-04-25T17:43:14.048807Z",
+     "iopub.status.busy": "2024-04-25T17:43:14.047868Z",
+     "iopub.status.idle": "2024-04-25T17:43:17.569604Z",
+     "shell.execute_reply": "2024-04-25T17:43:17.569354Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:14.048787Z"
     }
    },
    "outputs": [
@@ -1119,7 +1119,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "45.7 ms ± 3.26 ms per loop (mean ± std. dev. of 7 runs, 20 loops each)\n"
+      "25.1 ms ± 795 µs per loop (mean ± std. dev. of 7 runs, 20 loops each)\n"
      ]
     }
    ],
@@ -1138,15 +1138,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 26,
    "id": "1adbc415-672d-41cc-ba70-7efc98c952ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:59:31.286509Z",
-     "iopub.status.busy": "2024-04-22T17:59:31.286355Z",
-     "iopub.status.idle": "2024-04-22T17:59:34.255025Z",
-     "shell.execute_reply": "2024-04-22T17:59:34.254677Z",
-     "shell.execute_reply.started": "2024-04-22T17:59:31.286495Z"
+     "iopub.execute_input": "2024-04-25T17:43:17.570341Z",
+     "iopub.status.busy": "2024-04-25T17:43:17.570262Z",
+     "iopub.status.idle": "2024-04-25T17:43:19.144026Z",
+     "shell.execute_reply": "2024-04-25T17:43:19.143767Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:17.570333Z"
     }
    },
    "outputs": [
@@ -1154,7 +1154,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "21.2 ms ± 4.02 ms per loop (mean ± std. dev. of 7 runs, 20 loops each)\n"
+      "11.2 ms ± 305 µs per loop (mean ± std. dev. of 7 runs, 20 loops each)\n"
      ]
     }
    ],
@@ -1185,15 +1185,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 27,
    "id": "8965d16a-1703-4a75-9729-d8fbadb7a1c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:59:38.308011Z",
-     "iopub.status.busy": "2024-04-22T17:59:38.307828Z",
-     "iopub.status.idle": "2024-04-22T17:59:38.534424Z",
-     "shell.execute_reply": "2024-04-22T17:59:38.533146Z",
-     "shell.execute_reply.started": "2024-04-22T17:59:38.307996Z"
+     "iopub.execute_input": "2024-04-25T17:43:19.144482Z",
+     "iopub.status.busy": "2024-04-25T17:43:19.144412Z",
+     "iopub.status.idle": "2024-04-25T17:43:19.285784Z",
+     "shell.execute_reply": "2024-04-25T17:43:19.285493Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:19.144476Z"
     }
    },
    "outputs": [
@@ -1221,7 +1221,7 @@
        "└─────────────┴─────────────┘"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1237,15 +1237,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 28,
    "id": "aa610cd9-3b3f-43ce-b9cc-24a92df55307",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:59:38.951969Z",
-     "iopub.status.busy": "2024-04-22T17:59:38.951696Z",
-     "iopub.status.idle": "2024-04-22T17:59:38.955717Z",
-     "shell.execute_reply": "2024-04-22T17:59:38.955314Z",
-     "shell.execute_reply.started": "2024-04-22T17:59:38.951953Z"
+     "iopub.execute_input": "2024-04-25T17:43:19.286825Z",
+     "iopub.status.busy": "2024-04-25T17:43:19.286732Z",
+     "iopub.status.idle": "2024-04-25T17:43:19.289073Z",
+     "shell.execute_reply": "2024-04-25T17:43:19.288869Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:19.286817Z"
     }
    },
    "outputs": [],
@@ -1279,15 +1279,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 29,
    "id": "33a8ee68-dc8b-4a2e-a590-73a4998bc33e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:59:39.402297Z",
-     "iopub.status.busy": "2024-04-22T17:59:39.398741Z",
-     "iopub.status.idle": "2024-04-22T17:59:39.456982Z",
-     "shell.execute_reply": "2024-04-22T17:59:39.456425Z",
-     "shell.execute_reply.started": "2024-04-22T17:59:39.402269Z"
+     "iopub.execute_input": "2024-04-25T17:43:19.289563Z",
+     "iopub.status.busy": "2024-04-25T17:43:19.289458Z",
+     "iopub.status.idle": "2024-04-25T17:43:19.298677Z",
+     "shell.execute_reply": "2024-04-25T17:43:19.298408Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:19.289555Z"
     }
    },
    "outputs": [
@@ -1324,7 +1324,7 @@
        "└─────────────────────────────────┴─────────────────────────────────┴────────────────────┘"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1361,15 +1361,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 30,
    "id": "ff412921-2c2d-46b3-baad-d54067fa3312",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:59:39.761606Z",
-     "iopub.status.busy": "2024-04-22T17:59:39.761430Z",
-     "iopub.status.idle": "2024-04-22T17:59:39.790918Z",
-     "shell.execute_reply": "2024-04-22T17:59:39.790278Z",
-     "shell.execute_reply.started": "2024-04-22T17:59:39.761592Z"
+     "iopub.execute_input": "2024-04-25T17:43:19.299183Z",
+     "iopub.status.busy": "2024-04-25T17:43:19.299105Z",
+     "iopub.status.idle": "2024-04-25T17:43:19.305997Z",
+     "shell.execute_reply": "2024-04-25T17:43:19.305759Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:19.299176Z"
     }
    },
    "outputs": [
@@ -1383,7 +1383,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (5, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>group</th><th>coefficients</th></tr><tr><td>i64</td><td>struct[2]</td></tr></thead><tbody><tr><td>3</td><td>{-1.074243,-1.050159}</td></tr><tr><td>0</td><td>{-1.028893,-1.004733}</td></tr><tr><td>2</td><td>{-0.948578,-0.917406}</td></tr><tr><td>4</td><td>{-1.037308,-0.981468}</td></tr><tr><td>1</td><td>{-1.094156,-0.946028}</td></tr></tbody></table></div>"
+       "<small>shape: (5, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>group</th><th>coefficients</th></tr><tr><td>i64</td><td>struct[2]</td></tr></thead><tbody><tr><td>2</td><td>{-0.948578,-0.917406}</td></tr><tr><td>1</td><td>{-1.094156,-0.946028}</td></tr><tr><td>0</td><td>{-1.028893,-1.004733}</td></tr><tr><td>3</td><td>{-1.074243,-1.050159}</td></tr><tr><td>4</td><td>{-1.037308,-0.981468}</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (5, 2)\n",
@@ -1392,15 +1392,15 @@
        "│ ---   ┆ ---                   │\n",
        "│ i64   ┆ struct[2]             │\n",
        "╞═══════╪═══════════════════════╡\n",
-       "│ 3     ┆ {-1.074243,-1.050159} │\n",
-       "│ 0     ┆ {-1.028893,-1.004733} │\n",
        "│ 2     ┆ {-0.948578,-0.917406} │\n",
-       "│ 4     ┆ {-1.037308,-0.981468} │\n",
        "│ 1     ┆ {-1.094156,-0.946028} │\n",
+       "│ 0     ┆ {-1.028893,-1.004733} │\n",
+       "│ 3     ┆ {-1.074243,-1.050159} │\n",
+       "│ 4     ┆ {-1.037308,-0.981468} │\n",
        "└───────┴───────────────────────┘"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1426,15 +1426,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 31,
    "id": "931b667e-cf4d-4b53-be9b-85278c6fd16c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-04-22T17:59:39.931175Z",
-     "iopub.status.busy": "2024-04-22T17:59:39.929688Z",
-     "iopub.status.idle": "2024-04-22T17:59:39.979453Z",
-     "shell.execute_reply": "2024-04-22T17:59:39.970658Z",
-     "shell.execute_reply.started": "2024-04-22T17:59:39.931155Z"
+     "iopub.execute_input": "2024-04-25T17:43:19.306593Z",
+     "iopub.status.busy": "2024-04-25T17:43:19.306517Z",
+     "iopub.status.idle": "2024-04-25T17:43:19.311957Z",
+     "shell.execute_reply": "2024-04-25T17:43:19.311739Z",
+     "shell.execute_reply.started": "2024-04-25T17:43:19.306585Z"
     }
    },
    "outputs": [
@@ -1473,7 +1473,7 @@
        "└───────┴──────────────────┘"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1500,25 +1500,163 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0859cfce-2084-429d-b9ee-7b54bf5b5f4d",
+   "cell_type": "markdown",
+   "id": "441f1497-ca42-4550-8f2d-74e38dcf1512",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "### 6. Multi-output Regression\n",
+    "\n",
+    "- Say you are dealing with a situation where multiple targets are being regressed on the same set of features\n",
+    "- Given solution to OLS problem is `inv(X.T @ X) X.T @ Y` one can note that this is equivalent to running multiple independent regressions for each target\n",
+    "- But that is wasteful as `inv(X.T @ X) X.T` is a common factor\n",
+    "- For this reason the package exposes `compute_multi_target_least_squares` & `least_squares.multi_target_ols` which use SVD (and compute it on `X` only once)\n",
+    "- To use this functionality: pass a polars expression yielding a struct series as target. Other parameters are the same as standard least squares functions."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "8e681f36-f53c-4085-8f61-802f00922e34",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-25T17:49:01.929212Z",
+     "iopub.status.busy": "2024-04-25T17:49:01.928773Z",
+     "iopub.status.idle": "2024-04-25T17:49:01.937337Z",
+     "shell.execute_reply": "2024-04-25T17:49:01.936382Z",
+     "shell.execute_reply.started": "2024-04-25T17:49:01.929186Z"
+    }
+   },
    "outputs": [],
-   "source": []
+   "source": [
+    "df_multi_target = df.with_columns(\n",
+    "    pl.struct(\n",
+    "        y1=pl.col(\"x1\") + pl.col(\"x2\") + pl.col(\"x3\"),\n",
+    "        y2=pl.col(\"x1\") - pl.col(\"x2\") + pl.col(\"x3\"),\n",
+    "        y3=-pl.col(\"x1\") + pl.col(\"x2\") - pl.col(\"x3\"),\n",
+    "    ).alias(\"y\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "e3f80629-bf32-4c41-a75c-4490f245ebce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-25T17:49:56.704869Z",
+     "iopub.status.busy": "2024-04-25T17:49:56.704139Z",
+     "iopub.status.idle": "2024-04-25T17:49:56.713067Z",
+     "shell.execute_reply": "2024-04-25T17:49:56.712279Z",
+     "shell.execute_reply.started": "2024-04-25T17:49:56.704819Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (5, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>x1</th><th>x2</th><th>x3</th><th>y</th><th>group</th><th>sample_weights</th></tr><tr><td>f64</td><td>f64</td><td>f64</td><td>struct[3]</td><td>i64</td><td>f64</td></tr></thead><tbody><tr><td>0.12573</td><td>-0.132105</td><td>0.640423</td><td>{0.634048,0.898258,-0.898258}</td><td>1</td><td>0.709215</td></tr><tr><td>0.1049</td><td>-0.535669</td><td>0.361595</td><td>{-0.069174,1.002165,-1.002165}</td><td>0</td><td>0.731333</td></tr><tr><td>1.304</td><td>0.947081</td><td>-0.703735</td><td>{1.547346,-0.346816,0.346816}</td><td>4</td><td>0.701351</td></tr><tr><td>-1.265421</td><td>-0.623274</td><td>0.041326</td><td>{-1.84737,-0.600821,0.600821}</td><td>3</td><td>0.052596</td></tr><tr><td>-2.325031</td><td>-0.218792</td><td>-1.245911</td><td>{-3.789733,-3.35215,3.35215}</td><td>3</td><td>0.963254</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (5, 6)\n",
+       "┌───────────┬───────────┬───────────┬────────────────────────────────┬───────┬────────────────┐\n",
+       "│ x1        ┆ x2        ┆ x3        ┆ y                              ┆ group ┆ sample_weights │\n",
+       "│ ---       ┆ ---       ┆ ---       ┆ ---                            ┆ ---   ┆ ---            │\n",
+       "│ f64       ┆ f64       ┆ f64       ┆ struct[3]                      ┆ i64   ┆ f64            │\n",
+       "╞═══════════╪═══════════╪═══════════╪════════════════════════════════╪═══════╪════════════════╡\n",
+       "│ 0.12573   ┆ -0.132105 ┆ 0.640423  ┆ {0.634048,0.898258,-0.898258}  ┆ 1     ┆ 0.709215       │\n",
+       "│ 0.1049    ┆ -0.535669 ┆ 0.361595  ┆ {-0.069174,1.002165,-1.002165} ┆ 0     ┆ 0.731333       │\n",
+       "│ 1.304     ┆ 0.947081  ┆ -0.703735 ┆ {1.547346,-0.346816,0.346816}  ┆ 4     ┆ 0.701351       │\n",
+       "│ -1.265421 ┆ -0.623274 ┆ 0.041326  ┆ {-1.84737,-0.600821,0.600821}  ┆ 3     ┆ 0.052596       │\n",
+       "│ -2.325031 ┆ -0.218792 ┆ -1.245911 ┆ {-3.789733,-3.35215,3.35215}   ┆ 3     ┆ 0.963254       │\n",
+       "└───────────┴───────────┴───────────┴────────────────────────────────┴───────┴────────────────┘"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_multi_target.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "1cc3738f-89f4-4bce-b780-04f0c96c2bc9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-04-25T17:55:18.525628Z",
+     "iopub.status.busy": "2024-04-25T17:55:18.525326Z",
+     "iopub.status.idle": "2024-04-25T17:55:18.534221Z",
+     "shell.execute_reply": "2024-04-25T17:55:18.533746Z",
+     "shell.execute_reply.started": "2024-04-25T17:55:18.525605Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (5, 7)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>x1</th><th>x2</th><th>x3</th><th>y</th><th>group</th><th>sample_weights</th><th>residuals</th></tr><tr><td>f64</td><td>f64</td><td>f64</td><td>struct[3]</td><td>i64</td><td>f64</td><td>struct[3]</td></tr></thead><tbody><tr><td>0.12573</td><td>-0.132105</td><td>0.640423</td><td>{0.634048,0.898258,-0.898258}</td><td>1</td><td>0.709215</td><td>{4.4409e-16,4.4409e-16,-4.4409e-16}</td></tr><tr><td>0.1049</td><td>-0.535669</td><td>0.361595</td><td>{-0.069174,1.002165,-1.002165}</td><td>0</td><td>0.731333</td><td>{-1.6515e-15,-8.8818e-16,8.8818e-16}</td></tr><tr><td>1.304</td><td>0.947081</td><td>-0.703735</td><td>{1.547346,-0.346816,0.346816}</td><td>4</td><td>0.701351</td><td>{1.3323e-15,3.8858e-16,-6.1062e-16}</td></tr><tr><td>-1.265421</td><td>-0.623274</td><td>0.041326</td><td>{-1.84737,-0.600821,0.600821}</td><td>3</td><td>0.052596</td><td>{-8.8818e-16,-1.3323e-15,1.3323e-15}</td></tr><tr><td>-2.325031</td><td>-0.218792</td><td>-1.245911</td><td>{-3.789733,-3.35215,3.35215}</td><td>3</td><td>0.963254</td><td>{-1.3323e-15,-4.4409e-16,4.4409e-16}</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (5, 7)\n",
+       "┌───────────┬───────────┬───────────┬──────────────────┬───────┬────────────────┬──────────────────┐\n",
+       "│ x1        ┆ x2        ┆ x3        ┆ y                ┆ group ┆ sample_weights ┆ residuals        │\n",
+       "│ ---       ┆ ---       ┆ ---       ┆ ---              ┆ ---   ┆ ---            ┆ ---              │\n",
+       "│ f64       ┆ f64       ┆ f64       ┆ struct[3]        ┆ i64   ┆ f64            ┆ struct[3]        │\n",
+       "╞═══════════╪═══════════╪═══════════╪══════════════════╪═══════╪════════════════╪══════════════════╡\n",
+       "│ 0.12573   ┆ -0.132105 ┆ 0.640423  ┆ {0.634048,0.8982 ┆ 1     ┆ 0.709215       ┆ {4.4409e-16,4.44 │\n",
+       "│           ┆           ┆           ┆ 58,-0.898258}    ┆       ┆                ┆ 09e-16,-4.4409e- │\n",
+       "│           ┆           ┆           ┆                  ┆       ┆                ┆ …                │\n",
+       "│ 0.1049    ┆ -0.535669 ┆ 0.361595  ┆ {-0.069174,1.002 ┆ 0     ┆ 0.731333       ┆ {-1.6515e-15,-8. │\n",
+       "│           ┆           ┆           ┆ 165,-1.002165}   ┆       ┆                ┆ 8818e-16,8.8818e │\n",
+       "│           ┆           ┆           ┆                  ┆       ┆                ┆ …                │\n",
+       "│ 1.304     ┆ 0.947081  ┆ -0.703735 ┆ {1.547346,-0.346 ┆ 4     ┆ 0.701351       ┆ {1.3323e-15,3.88 │\n",
+       "│           ┆           ┆           ┆ 816,0.346816}    ┆       ┆                ┆ 58e-16,-6.1062e- │\n",
+       "│           ┆           ┆           ┆                  ┆       ┆                ┆ …                │\n",
+       "│ -1.265421 ┆ -0.623274 ┆ 0.041326  ┆ {-1.84737,-0.600 ┆ 3     ┆ 0.052596       ┆ {-8.8818e-16,-1. │\n",
+       "│           ┆           ┆           ┆ 821,0.600821}    ┆       ┆                ┆ 3323e-15,1.3323e │\n",
+       "│           ┆           ┆           ┆                  ┆       ┆                ┆ …                │\n",
+       "│ -2.325031 ┆ -0.218792 ┆ -1.245911 ┆ {-3.789733,-3.35 ┆ 3     ┆ 0.963254       ┆ {-1.3323e-15,-4. │\n",
+       "│           ┆           ┆           ┆ 215,3.35215}     ┆       ┆                ┆ 4409e-16,4.4409e │\n",
+       "│           ┆           ┆           ┆                  ┆       ┆                ┆ …                │\n",
+       "└───────────┴───────────┴───────────┴──────────────────┴───────┴────────────────┴──────────────────┘"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# do multi-target .. it works\n",
+    "df_multi_target.with_columns(\n",
+    "    pl.col(\"y\").least_squares.multi_target_ols(\"x1\", \"x2\", \"x3\", \n",
+    "                                               sample_weights=\"sample_weights\",\n",
+    "                                               mode=\"residuals\",\n",
+    "                                              ).over(\"group\").alias(\"residuals\")\n",
+    ").head()"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e3f80629-bf32-4c41-a75c-4490f245ebce",
+   "id": "e010b5cf-aa98-4bc4-a1d3-9a32ee43d611",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/tests/test_ols.py
+++ b/tests/test_ols.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy as np
 import polars as pl
@@ -13,6 +13,7 @@ from polars_ols import (
     SolveMethod,
     compute_least_squares,
     compute_least_squares_from_formula,
+    compute_multi_target_least_squares,
 )
 from polars_ols.utils import timer
 
@@ -23,6 +24,8 @@ def _make_data(
     n_groups: Optional[int] = None,
     scale: float = 0.1,
     sparsity: float = 0.0,
+    add_missing: bool = False,
+    missing_columns: Optional[Tuple[str, ...]] = None,
 ) -> pl.DataFrame:
     rng = np.random.default_rng(0)
     x = rng.normal(size=(n_samples, n_features))
@@ -35,6 +38,15 @@ def _make_data(
     if n_groups is not None:
         df = df.with_columns(group=pl.lit(rng.integers(n_groups, size=n_samples)))
 
+    if add_missing:
+
+        def insert_nulls(val):
+            return None if rng.random() < 0.1 else val
+
+        columns = missing_columns or df.columns
+        df = df.with_columns(
+            *(pl.col(c).map_elements(insert_nulls, return_dtype=pl.Float64) for c in columns)
+        )
     return df
 
 
@@ -43,7 +55,7 @@ def test_ols(solve_method: SolveMethod):
     import os
 
     os.environ["POLARS_VERBOSE"] = "1"
-    df = _make_data(n_samples=10, n_features=2)
+    df = _make_data(n_samples=1_000, n_features=2)
     # compute OLS w/ polars-ols
     with timer(f"\nOLS {solve_method}", precision=5):
         for _ in range(1_000):
@@ -63,16 +75,61 @@ def test_ols(solve_method: SolveMethod):
     assert np.allclose(df["predictions"], df["predictions2"], atol=1.0e-4, rtol=1.0e-4)
 
 
-def test_fit_missing_data_coefficients():
-    df = _make_data()
-    rng = np.random.default_rng(0)
-
-    def insert_nulls(val):
-        return None if rng.random() < 0.1 else val
-
-    df = df.with_columns(
-        *(pl.col(c).map_elements(insert_nulls, return_dtype=pl.Float64) for c in df.columns)
+@pytest.mark.parametrize(
+    "alpha,mode,null_policy",
+    [
+        (0.0, "residuals", "ignore"),
+        (0.0, "residuals", "drop"),
+        (0.0001, "residuals", "drop_y_zero_x"),
+        (0.01, "residuals", "drop_zero"),
+    ],
+)
+def test_multi_target_regression(alpha, mode, null_policy):
+    df = _make_data(
+        n_samples=10_000,
+        n_features=3,
+        add_missing=null_policy not in {"zero", "ignore"},
+        missing_columns=("x1",),
     )
+    df = df.with_columns(
+        pl.struct(
+            y1=pl.col("x1") + pl.col("x2") + pl.col("x3"),
+            y2=pl.col("x1") - pl.col("x2") + pl.col("x3"),
+            y3=-pl.col("x1") + pl.col("x2") - pl.col("x3"),
+        ).alias("y")
+    )
+    ols_kwargs = OLSKwargs(null_policy=null_policy, solve_method="svd", alpha=alpha)
+
+    with timer(f"compute multi-target (alpha={alpha}, null_policy={null_policy}, mode={mode})"):
+        multi_target = df.select(
+            compute_multi_target_least_squares(
+                "y",
+                "x1",
+                "x2",
+                "x3",
+                mode=mode,
+                ols_kwargs=ols_kwargs,
+            ).alias(mode)
+        )
+
+    with timer("compute multiple linear regressions"):
+        expected = df.unnest("y").select(
+            compute_least_squares(
+                target,
+                "x1",
+                "x2",
+                "x3",
+                mode=mode,
+                ols_kwargs=ols_kwargs,
+            ).alias(target)
+            for target in ("y1", "y2", "y3")
+        )
+
+    assert np.allclose(multi_target.unnest(mode), expected, equal_nan=True)
+
+
+def test_fit_missing_data_coefficients():
+    df = _make_data(add_missing=True)
 
     # in presence of unhandled nulls assert the rust library raises ComputeError
     with pytest.raises(pl.exceptions.ComputeError):
@@ -134,15 +191,7 @@ def test_fit_missing_data_coefficients():
 
 @pytest.mark.parametrize("null_policy", ["drop", "drop_zero", "drop_y_zero_x"])
 def test_fit_missing_data_predictions_and_residuals(null_policy: NullPolicy):
-    df = _make_data()
-    rng = np.random.default_rng(0)
-
-    def insert_nulls(val):
-        return None if rng.random() < 0.1 else val
-
-    df = df.with_columns(
-        *(pl.col(c).map_elements(insert_nulls, return_dtype=pl.Float64) for c in df.columns)
-    )
+    df = _make_data(add_missing=True)
 
     # check predictions logic
     with timer("numpy lstsq w/ manual nan policy", precision=5):
@@ -691,15 +740,7 @@ def test_recursive_least_squares_prior():
     ],
 )
 def test_rolling_least_squares(window_size: int, min_periods: int, use_woodbury: bool):
-    df = _make_data(n_samples=1_000)
-    rng = np.random.default_rng(0)
-
-    def insert_nulls(val):
-        return None if rng.random() < 0.1 else val
-
-    df = df.with_columns(
-        *(pl.col(c).map_elements(insert_nulls, return_dtype=pl.Float64) for c in ("y",))
-    )
+    df = _make_data(n_samples=1_000, add_missing=True, missing_columns=("y",))
 
     with timer("\nrolling ols"):
         coef_rolling = (
@@ -780,16 +821,7 @@ def test_rolling_ols_insufficient_data(min_periods: int, expected: int):
 
 @pytest.mark.parametrize("window_size", (21, 252))
 def test_rolling_window_drop(window_size: int):
-    df = _make_data(n_samples=1_000)
-    rng = np.random.default_rng(0)
-
-    def insert_nulls(val):
-        return None if rng.random() < 0.1 else val
-
-    df = df.with_columns(
-        *(pl.col(c).map_elements(insert_nulls, return_dtype=pl.Float64) for c in ("y",))
-    ).with_row_index()
-
+    df = _make_data(n_samples=1_000, add_missing=True, missing_columns=("y",)).with_row_index()
     df_drop = df.drop_nulls()
 
     df_merged = (


### PR DESCRIPTION
This PR adds support for multi-target regressions, where:

1. user is expected to pass a polars expression returning a polars struct for "targets". This struct contains the names and values of every target they wish to regress.
2. `*features`, `ols_kwargs`, and other parameters remain the same. The Rust implementation will convert the target series struct to a 2D ndarray and compute validity masks across all unnested target and feature series
3. LAPACK DGELSD or pure rust ridge SVD implementation is used to factorize "X" and solving against multiple 2D Y once 

Notebook, demo benchmark, and tests are updated with examples. 
For large number of targets, it is more efficient to use this multi-target functionality than to run multiple indepedent linear regressions. 

