### PR TITLE
release v0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "polars_ols"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "approx",
  "blas-src",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["profile-rustflags"]
 
 [package]
 name = "polars_ols"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ df = pl.DataFrame({"y": [1.16, -2.16, -1.57, 0.21, 0.22, 1.6, -2.11, -2.92, -0.8
                    "weights": [0.34, 0.97, 0.39, 0.8, 0.57, 0.41, 0.19, 0.87, 0.06, 0.34],
                    })
 
-lasso_expr = pl.col("y").least_squares.lasso(pl.col("x1"), pl.col("x2"), alpha=0.0001, add_intercept=True).over("group")
+lasso_expr = pl.col("y").least_squares.lasso("x1", "x2", alpha=0.0001, add_intercept=True).over("group")
 wls_expr = pls.compute_least_squares_from_formula("y ~ x1 + x2 -1", sample_weights=pl.col("weights"))
 
 predictions = df.with_columns(lasso_expr.round(2).alias("predictions_lasso"),
@@ -154,6 +154,7 @@ Currently, this extension package supports the following variants:
 - Weighted Least Squares: ```least_squares.wls```
 - Regularized Least Squares (Lasso / Ridge / Elastic Net) ```least_squares.{lasso, ridge, elastic_net}```
 - Non-negative Least Squares: ```least_squares.nnls```
+- Multi-target Least Squares:  ```least_squares.multi_target_ols```
 
 As well as efficient implementations of moving window models:
 - Recursive Least Squares: ```least_squares.rls```

--- a/src/least_squares.rs
+++ b/src/least_squares.rs
@@ -252,6 +252,11 @@ pub fn solve_multi_target(
     alpha: Option<f64>,
     rcond: Option<f64>,
 ) -> Array2<f64> {
+    // handle degenerate case of no data
+    if x.is_empty() {
+        return Array2::zeros((x.ncols(), y.ncols()));  // n_features x n_targets
+    }
+    // Choose SVD implementation based on L2 regularization
     let alpha = alpha.unwrap_or(0.0);
     if alpha > 0.0 {
         solve_ridge_svd(y, x, alpha, rcond)


### PR DESCRIPTION
- Integrates proposed fix here: https://github.com/pola-rs/pyo3-polars/issues/79#issuecomment-2079402085

This allows users to pass wildcard/multi-expressions for features: e.g. `pl.col("^x.*$")` to automatically capture any column starting with "x". This will also now work properly in `.group_by` / `.over` contexts

- handles empty data corner case for multi-target regression
- cosmetic updates to README and tests