### PR TITLE
Return NaN statistics if fit fails

### DIFF
--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -91,7 +91,7 @@ pub fn compute_feature_metrics(
     // Convert xtx_reg to a faer matrix
     let xtx_faer = xtx_reg.view().into_faer();
 
-    let mut nans = Array::zeros(features.len());
+    let mut nans = Array::zeros(features.ncols());
     nans.fill(f64::NAN);
 
     // Compute X^T y

--- a/tests/test_ols.py
+++ b/tests/test_ols.py
@@ -1029,6 +1029,31 @@ def test_least_squares_statistics():
     assert np.allclose(df_stats["p_values"], res.pvalues)
 
 
+def test_least_squares_statistics_fit_fails():
+    df = _make_data()
+    statistics = df.with_columns(pl.lit(0.0).alias("x0")).select(
+        pl.col("y").least_squares.ols(cs.starts_with("x"), mode="statistics", add_intercept=True)
+    )
+    statistics = statistics.unnest("statistics")
+
+    assert np.isnan(statistics["r2"].item())
+    assert np.isnan(statistics["mse"].item())
+
+    df_stats = (
+        statistics.explode(
+            ["feature_names", "coefficients", "standard_errors", "t_values", "p_values"]
+        )
+        .to_pandas()
+        .set_index("feature_names")
+        .rename(index={"const": "Intercept"})
+    )
+
+    assert np.all(~np.isfinite(df_stats["coefficients"]))
+    assert np.all(~np.isfinite(df_stats["standard_errors"]))
+    assert np.all(~np.isfinite(df_stats["t_values"]))
+    assert np.all(~np.isfinite(df_stats["p_values"]))
+
+
 def test_predict_formula():
     df = _make_data()
     df = (


### PR DESCRIPTION
Currently if the fit fails (e.g. column of 0s in the predictors) then `coefficients` will return nan/inf, but `statistics` will panic

This PR makes `statistics` also return NaNs

I'm a rust beginner, so apologies if this isn't the greatest rust code.